### PR TITLE
Full Tarkov death cost: gear loss, surviving quest items, keepsake, insurance

### DIFF
--- a/src/components/RunPreparationPanel.tsx
+++ b/src/components/RunPreparationPanel.tsx
@@ -1,6 +1,6 @@
 import { Button } from "./Button";
 import { formatResourceCost } from "../game/materials";
-import type { PreparedRunModifier, RunPreparationOption, VillageNpc } from "../game/types";
+import type { ItemInstance, PreparedRunModifier, RunPreparationOption, VillageNpc } from "../game/types";
 import { RUN_PREPARATION_RULES } from "../game/constants";
 
 export interface RunPreparationPanelProps {
@@ -27,6 +27,79 @@ export function RunPreparationPanel({ options, selectedPreparations, npcs = [], 
             </div>
             <Button variant="ghost" disabled={selected || !npc} onClick={() => npc && onPurchase(option.id, npc.id)}>
               {selected ? "Prepared" : "Prepare"}
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export interface KeepsakePanelProps {
+  candidates: ItemInstance[];
+  selectedInstanceId?: string;
+  onSelect: (itemInstanceId: string) => void;
+  onClear: () => void;
+}
+
+export function KeepsakePanel({ candidates, selectedInstanceId, onSelect, onClear }: KeepsakePanelProps) {
+  return (
+    <div className="run-preparation-panel">
+      <p className="muted small">One weightless packed item can be designated a keepsake. It survives even if you die below.</p>
+      {candidates.length === 0 ? (
+        <div className="inv-empty">Nothing weightless is packed.</div>
+      ) : candidates.map(item => {
+        const selected = selectedInstanceId === item.instanceId;
+        return (
+          <div className="prep-card" key={item.instanceId}>
+            <div>
+              <strong>{item.name}</strong>
+              <p>{item.description}</p>
+            </div>
+            <Button
+              variant="ghost"
+              onClick={() => (selected ? onClear() : onSelect(item.instanceId))}
+            >
+              {selected ? "Keepsake" : "Set as Keepsake"}
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export interface InsurancePanelProps {
+  candidates: ItemInstance[];
+  selectedInstanceId?: string;
+  getCost: (item: ItemInstance) => number;
+  gold: number;
+  onInsure: (itemInstanceId: string) => void;
+  onCancel: () => void;
+}
+
+export function InsurancePanel({ candidates, selectedInstanceId, getCost, gold, onInsure, onCancel }: InsurancePanelProps) {
+  return (
+    <div className="run-preparation-panel">
+      <p className="muted small">Insure one equipped piece of gear. If you die, it returns to the stash instead of being lost.</p>
+      {candidates.length === 0 ? (
+        <div className="inv-empty">Nothing is equipped.</div>
+      ) : candidates.map(item => {
+        const selected = selectedInstanceId === item.instanceId;
+        const cost = getCost(item);
+        const affordable = gold >= cost;
+        return (
+          <div className="prep-card" key={item.instanceId}>
+            <div>
+              <strong>{item.name}</strong>
+              <div className="muted small">{cost}g to insure</div>
+            </div>
+            <Button
+              variant="ghost"
+              disabled={!selected && (!!selectedInstanceId || !affordable)}
+              onClick={() => (selected ? onCancel() : onInsure(item.instanceId))}
+            >
+              {selected ? "Insured" : "Insure"}
             </Button>
           </div>
         );

--- a/src/game/constants.ts
+++ b/src/game/constants.ts
@@ -391,6 +391,8 @@ export const SERVICE_ACTION_RULES = {
   }
 } as const;
 
+export const INSURANCE_RATE = 0.3;
+
 export const RUN_PREPARATION_RULES = {
   maxPreparedModifiers: 3,
   maxByServiceRole: {

--- a/src/game/progression.ts
+++ b/src/game/progression.ts
@@ -7,9 +7,15 @@ import type {
   Inventory,
   MaterialVault
 } from "./types";
-import { moveRaidInventoryToStash, createEmptyInventory } from "./inventory";
+import { moveRaidInventoryToStash, createEmptyInventory, addItem } from "./inventory";
 import { instanceFromTemplateId } from "./inventory";
 import type { Rng } from "./rng";
+import { recalculateCharacterStats } from "./characterMath";
+import { getAncestry } from "../data/ancestries";
+import { getClass } from "../data/classes";
+
+const QUEST_ITEM_TAG = "quest";
+const EQUIPMENT_SLOTS = ["weapon", "offhand", "armor", "trinket1", "trinket2"] as const;
 
 export interface ExtractionRewardSummary {
   goldGained: number;
@@ -75,35 +81,117 @@ export interface DeathSummary {
   gearLost: ItemInstance[];
   materialsLost: MaterialVault;
   goldLost: number;
+  questItemsSaved: ItemInstance[];
+  keepsakeSaved?: ItemInstance;
+  insuranceReturned?: ItemInstance;
 }
 
+function isQuestItem(item: ItemInstance): boolean {
+  return item.tags?.includes(QUEST_ITEM_TAG) ?? false;
+}
+
+/**
+ * Full Tarkov death rule: the raid pack and all equipped gear are lost.
+ * Quest items always survive (tags include "quest") — losing them can
+ * soft-lock quest chains. A designated keepsake (weightless raid-pack item)
+ * and an insured piece of gear may also survive; the insured piece is
+ * unequipped and returned to the stash rather than staying on the character.
+ */
 export function applyDeathPenalty(run: DungeonRun): { run: DungeonRun; summary: DeathSummary } {
-  const raidItemsLost = [...run.raidInventory.items];
-  const gearLost = run.loadoutSnapshot.filter(i => !i.protected);
+  const allRaidItems = run.raidInventory.items;
+  const questItemsSaved = allRaidItems.filter(isQuestItem);
+  const keepsakeSaved = run.keepsakeInstanceId
+    ? allRaidItems.find(
+        item => item.instanceId === run.keepsakeInstanceId && item.weight === 0 && item.quantity === 1 && !isQuestItem(item)
+      )
+    : undefined;
+  const savedRaidIds = new Set(
+    [...questItemsSaved, ...(keepsakeSaved ? [keepsakeSaved] : [])].map(item => item.instanceId)
+  );
+  const raidItemsLost = allRaidItems.filter(item => !savedRaidIds.has(item.instanceId));
+
+  const insuranceReturned = run.insuredInstanceId
+    ? run.loadoutSnapshot.find(item => item.instanceId === run.insuredInstanceId)
+    : undefined;
+  const gearLost = run.loadoutSnapshot.filter(
+    item => !item.protected && item.instanceId !== run.insuredInstanceId
+  );
+
   const summary: DeathSummary = {
     itemsLost: [...raidItemsLost, ...gearLost],
     raidItemsLost,
     gearLost,
     materialsLost: { ...(run.raidInventory.materials ?? {}) },
-    goldLost: run.raidInventory.gold
+    goldLost: run.raidInventory.gold,
+    questItemsSaved,
+    keepsakeSaved,
+    insuranceReturned
   };
   const next: DungeonRun = {
     ...run,
     status: "dead",
     raidInventory: createEmptyInventory(),
-    loadoutSnapshot: run.loadoutSnapshot.filter(i => i.protected)
+    loadoutSnapshot: run.loadoutSnapshot.filter(item => item.protected)
   };
   return { run: next, summary };
 }
 
+/**
+ * Pure resolution of a death: applies the penalty, moves every surviving
+ * item (quest items, keepsake, insured gear) into the stash, and unequips
+ * whatever the character no longer has (lost gear and the insured piece,
+ * which now lives in the stash instead of on the body).
+ */
+export function resolveDeathOutcome(params: {
+  run: DungeonRun;
+  player: Character;
+  stash: Inventory;
+}): { run: DungeonRun; player: Character; stash: Inventory; summary: DeathSummary } {
+  const { run, player, stash } = params;
+  const { run: deadRun, summary } = applyDeathPenalty(run);
+
+  const survivors: ItemInstance[] = [
+    ...summary.questItemsSaved,
+    ...(summary.keepsakeSaved ? [summary.keepsakeSaved] : []),
+    ...(summary.insuranceReturned ? [summary.insuranceReturned] : [])
+  ];
+  let nextStash = stash;
+  for (const item of survivors) {
+    nextStash = addItem(nextStash, item);
+  }
+
+  const unequipIds = new Set([
+    ...summary.gearLost.map(item => item.instanceId),
+    ...(summary.insuranceReturned ? [summary.insuranceReturned.instanceId] : [])
+  ]);
+  const equipped = { ...player.equipped };
+  for (const slot of EQUIPMENT_SLOTS) {
+    const item = equipped[slot];
+    if (item && unequipIds.has(item.instanceId)) {
+      equipped[slot] = undefined;
+    }
+  }
+  const recalculated = recalculateCharacterStats(
+    { ...player, equipped, wounded: undefined },
+    getAncestry(player.ancestryId),
+    getClass(player.classId)
+  );
+  const recoveredPlayer: Character = { ...recalculated, hp: recalculated.maxHp, wounded: undefined };
+
+  return { run: deadRun, player: recoveredPlayer, stash: nextStash, summary };
+}
+
 export function applyAbandonPenalty(run: DungeonRun): { run: DungeonRun; summary: DeathSummary } {
   const raidItemsLost = [...run.raidInventory.items];
+  const questItemsSaved = raidItemsLost.filter(isQuestItem);
+  const savedIds = new Set(questItemsSaved.map(item => item.instanceId));
   const summary: DeathSummary = {
-    itemsLost: raidItemsLost,
-    raidItemsLost,
+    itemsLost: raidItemsLost.filter(item => !savedIds.has(item.instanceId)),
+    raidItemsLost: raidItemsLost.filter(item => !savedIds.has(item.instanceId)),
     gearLost: [],
     materialsLost: { ...(run.raidInventory.materials ?? {}) },
-    goldLost: run.raidInventory.gold
+    goldLost: run.raidInventory.gold,
+    questItemsSaved
   };
   const next: DungeonRun = {
     ...run,
@@ -111,6 +199,26 @@ export function applyAbandonPenalty(run: DungeonRun): { run: DungeonRun; summary
     raidInventory: createEmptyInventory()
   };
   return { run: next, summary };
+}
+
+/**
+ * Pure resolution of an abandoned run: quest items in the raid pack
+ * always survive (same soft-lock rationale as death) and are moved to
+ * the stash. Equipped gear is untouched — abandoning does not cost gear.
+ */
+export function resolveAbandonOutcome(params: {
+  run: DungeonRun;
+  player: Character;
+  stash: Inventory;
+}): { run: DungeonRun; player: Character; stash: Inventory; summary: DeathSummary } {
+  const { run, player, stash } = params;
+  const { run: abandonedRun, summary } = applyAbandonPenalty(run);
+  let nextStash = stash;
+  for (const item of summary.questItemsSaved) {
+    nextStash = addItem(nextStash, item);
+  }
+  const recoveredPlayer: Character = { ...player, hp: player.maxHp, wounded: undefined };
+  return { run: abandonedRun, player: recoveredPlayer, stash: nextStash, summary };
 }
 
 export function applyXpAndLevel(player: Character): Character {

--- a/src/game/runPreparation.ts
+++ b/src/game/runPreparation.ts
@@ -1,6 +1,6 @@
 import { RUN_PREPARATION_OPTIONS, getRunPreparationOption } from "../data/runPreparationOptions";
-import { RUN_PREPARATION_RULES } from "./constants";
-import type { Character, DungeonRun, GameState, PreparedRunModifier, RunPreparationOption } from "./types";
+import { INSURANCE_RATE, RUN_PREPARATION_RULES } from "./constants";
+import type { Character, DungeonRun, GameState, ItemInstance, PreparedRunModifier, RunPreparationOption } from "./types";
 import type { Rng } from "./rng";
 import { createRng, makeId } from "./rng";
 import { addItem, instanceFromTemplateId } from "./inventory";
@@ -175,4 +175,112 @@ export function consumeRunPreparations(params: {
     ...params.gameState,
     pendingRunPreparations: (params.gameState.pendingRunPreparations ?? []).filter(prep => !prep.consumed)
   };
+}
+
+// --- Insurance ---
+// A village service: insure one equipped gear piece per run for gold
+// (priced at a fraction of the item's value). If the character dies, the
+// insured piece is unequipped and returned to the stash instead of being
+// lost with the rest of the raid.
+
+export function getInsuranceCost(item: ItemInstance): number {
+  return Math.max(1, Math.ceil(item.value * INSURANCE_RATE));
+}
+
+function findEquippedItem(character: Character, itemInstanceId: string): ItemInstance | undefined {
+  return Object.values(character.equipped).find(
+    (item): item is ItemInstance => Boolean(item) && item!.instanceId === itemInstanceId
+  );
+}
+
+export function canPurchaseInsurance(params: {
+  gameState: GameState;
+  itemInstanceId: string;
+}): { canPurchase: boolean; reason?: string; cost?: number } {
+  if (params.gameState.activeRun) return { canPurchase: false, reason: "Insure gear before the next delve." };
+  const character = params.gameState.player;
+  if (!character) return { canPurchase: false, reason: "No active character." };
+  const item = findEquippedItem(character, params.itemInstanceId);
+  if (!item) return { canPurchase: false, reason: "That item isn't equipped." };
+  if (params.gameState.pendingInsuredInstanceId) {
+    return { canPurchase: false, reason: "Only one piece can be insured per run." };
+  }
+  const cost = getInsuranceCost(item);
+  if (params.gameState.stash.gold < cost) {
+    return { canPurchase: false, reason: "Not enough gold.", cost };
+  }
+  return { canPurchase: true, cost };
+}
+
+export function purchaseInsurance(params: {
+  gameState: GameState;
+  itemInstanceId: string;
+}): { gameState: GameState; success: boolean; message: string } {
+  const gate = canPurchaseInsurance(params);
+  if (!gate.canPurchase || gate.cost === undefined) {
+    return { gameState: params.gameState, success: false, message: gate.reason ?? "Cannot insure that item." };
+  }
+  const item = findEquippedItem(params.gameState.player!, params.itemInstanceId)!;
+  return {
+    gameState: {
+      ...params.gameState,
+      stash: { ...params.gameState.stash, gold: params.gameState.stash.gold - gate.cost },
+      pendingInsuredInstanceId: params.itemInstanceId
+    },
+    success: true,
+    message: `${item.name} insured for ${gate.cost}g. It returns to the stash if you die.`
+  };
+}
+
+export function cancelInsurance(gameState: GameState): GameState {
+  return { ...gameState, pendingInsuredInstanceId: undefined };
+}
+
+// --- Keepsake ---
+// Exactly one weightless item packed for the next raid may be designated
+// as a keepsake. It survives death even though the rest of the raid pack
+// is lost.
+
+function isKeepsakeEligible(item: ItemInstance): boolean {
+  // "Exactly one item" — a stack of several weightless items (e.g. gems)
+  // would let the whole stack ride out death, so only single, non-stacked
+  // items qualify.
+  return item.weight === 0 && item.quantity === 1;
+}
+
+export function getKeepsakeCandidates(gameState: GameState): ItemInstance[] {
+  return gameState.preparedInventory.items.filter(isKeepsakeEligible);
+}
+
+export function canDesignateKeepsake(params: {
+  gameState: GameState;
+  itemInstanceId: string;
+}): { canDesignate: boolean; reason?: string } {
+  if (params.gameState.activeRun) return { canDesignate: false, reason: "Choose a keepsake before the next delve." };
+  const item = params.gameState.preparedInventory.items.find(entry => entry.instanceId === params.itemInstanceId);
+  if (!item) return { canDesignate: false, reason: "Pack the item for the next raid first." };
+  if (!isKeepsakeEligible(item)) {
+    return { canDesignate: false, reason: "Only a single weightless item can be a keepsake." };
+  }
+  return { canDesignate: true };
+}
+
+export function setKeepsake(params: {
+  gameState: GameState;
+  itemInstanceId: string;
+}): { gameState: GameState; success: boolean; message: string } {
+  const gate = canDesignateKeepsake(params);
+  if (!gate.canDesignate) {
+    return { gameState: params.gameState, success: false, message: gate.reason ?? "Cannot set that keepsake." };
+  }
+  const item = params.gameState.preparedInventory.items.find(entry => entry.instanceId === params.itemInstanceId)!;
+  return {
+    gameState: { ...params.gameState, pendingKeepsakeInstanceId: params.itemInstanceId },
+    success: true,
+    message: `${item.name} set as your keepsake. It survives even if you die.`
+  };
+}
+
+export function clearKeepsake(gameState: GameState): GameState {
+  return { ...gameState, pendingKeepsakeInstanceId: undefined };
 }

--- a/src/game/runSummary.ts
+++ b/src/game/runSummary.ts
@@ -69,7 +69,10 @@ export function buildRunSummary({
     questProgress: getQuestProgress(run, village),
     questsCompleted: extraction?.questsCompleted ?? getCompletedRunQuests(run, village),
     questRewards: extraction?.questRewards ?? [],
-    unlocksApplied: extraction?.unlocksApplied ?? []
+    unlocksApplied: extraction?.unlocksApplied ?? [],
+    questItemsSaved: death?.questItemsSaved ?? [],
+    keepsakeSaved: death?.keepsakeSaved,
+    insuranceReturned: death?.insuranceReturned
   };
 }
 

--- a/src/game/save.ts
+++ b/src/game/save.ts
@@ -359,6 +359,9 @@ function normalizeRunSummary(value: unknown): RunSummary | undefined {
     gearLost: Array.isArray(value.gearLost) ? value.gearLost.map(normalizeItem).filter(Boolean) : [],
     materialsExtracted: normalizeMaterialVault(value.materialsExtracted),
     materialsLost: normalizeMaterialVault(value.materialsLost),
-    questRewards: Array.isArray(value.questRewards) ? value.questRewards.map(normalizeItem).filter(Boolean) : []
+    questRewards: Array.isArray(value.questRewards) ? value.questRewards.map(normalizeItem).filter(Boolean) : [],
+    questItemsSaved: Array.isArray(value.questItemsSaved) ? value.questItemsSaved.map(normalizeItem).filter(Boolean) : [],
+    keepsakeSaved: normalizeItem(value.keepsakeSaved),
+    insuranceReturned: normalizeItem(value.insuranceReturned)
   } as RunSummary;
 }

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -689,6 +689,8 @@ export interface DungeonRun {
     turnsRemaining: number;
   };
   appliedRunPreparations?: PreparedRunModifier[];
+  keepsakeInstanceId?: string;
+  insuredInstanceId?: string;
 }
 
 export type NpcRole =
@@ -1027,6 +1029,8 @@ export interface GameState {
   lastRunSummary?: RunSummary;
   settings: GameSettings;
   pendingRunPreparations?: PreparedRunModifier[];
+  pendingKeepsakeInstanceId?: string;
+  pendingInsuredInstanceId?: string;
 }
 
 export type RunEndReason =
@@ -1073,6 +1077,9 @@ export interface RunSummary {
   questsCompleted: Quest[];
   questRewards: ItemInstance[];
   unlocksApplied: string[];
+  questItemsSaved: ItemInstance[];
+  keepsakeSaved?: ItemInstance;
+  insuranceReturned?: ItemInstance;
 }
 
 export type ScreenId =

--- a/src/screens/RunSummaryScreen.tsx
+++ b/src/screens/RunSummaryScreen.tsx
@@ -85,6 +85,31 @@ export function RunSummaryScreen() {
         />
       </Card>
 
+      {(summary.reason === "dead" || summary.reason === "abandoned") &&
+        (summary.questItemsSaved.length > 0 || summary.keepsakeSaved || summary.insuranceReturned) && (
+        <Card title="What Survived">
+          {summary.questItemsSaved.length > 0 && (
+            <>
+              <h4 className="good">Quest Items</h4>
+              <ItemList items={summary.questItemsSaved} empty="No quest items were carried." />
+            </>
+          )}
+          {summary.keepsakeSaved && (
+            <>
+              <h4 className="good">Keepsake</h4>
+              <ItemList items={[summary.keepsakeSaved]} empty="No keepsake was set." />
+            </>
+          )}
+          {summary.insuranceReturned && (
+            <>
+              <h4 className="good">Insurance</h4>
+              <p className="muted small">Returned to the stash rather than kept equipped.</p>
+              <ItemList items={[summary.insuranceReturned]} empty="No gear was insured." />
+            </>
+          )}
+        </Card>
+      )}
+
       {(protectedItems.length > 0 || brokenItems.length > 0) && (
         <Card title="Item Fate">
           {protectedItems.length > 0 && (

--- a/src/screens/StashScreen.tsx
+++ b/src/screens/StashScreen.tsx
@@ -6,10 +6,10 @@ import { ItemComparePanel } from "../components/ItemComparePanel";
 import { ItemTooltip } from "../components/ItemTooltip";
 import { LoadoutBuilder } from "../components/LoadoutBuilder";
 import { MaterialInventory } from "../components/MaterialInventory";
-import { RunPreparationPanel } from "../components/RunPreparationPanel";
+import { InsurancePanel, KeepsakePanel, RunPreparationPanel } from "../components/RunPreparationPanel";
 import { calculateInventoryWeight } from "../game/inventory";
 import { getConsumableHealFormula } from "../game/itemEffects";
-import { getAvailableRunPreparationOptions } from "../game/runPreparation";
+import { getAvailableRunPreparationOptions, getInsuranceCost, getKeepsakeCandidates } from "../game/runPreparation";
 import type { EquipmentSlots, Inventory, ItemInstance } from "../game/types";
 import { useGameStore } from "../store/gameStore";
 import type { EquipmentChangePreview, EquipmentSlotName } from "../components/v04UiTypes";
@@ -31,6 +31,10 @@ export function StashScreen() {
   const dropRaidItem = useGameStore(s => s.dropRaidItem);
   const useCombatItem = useGameStore(s => s.useCombatInventoryItem);
   const purchasePreparation = useGameStore(s => s.purchaseRunPreparation);
+  const setKeepsake = useGameStore(s => s.setKeepsake);
+  const clearKeepsake = useGameStore(s => s.clearKeepsake);
+  const purchaseInsurance = useGameStore(s => s.purchaseInsurance);
+  const cancelInsurance = useGameStore(s => s.cancelInsurance);
   const genericEquip = useGameStore(s => s.equipItem);
   const genericUnequip = useGameStore(s => s.unequipItem);
   const previewEquipmentChange = useGameStore(s => s.previewEquipmentChange);
@@ -151,6 +155,26 @@ export function StashScreen() {
                 selectedPreparations={state.pendingRunPreparations ?? []}
                 npcs={state.village?.npcs ?? []}
                 onPurchase={(optionId, npcId) => purchasePreparation(npcId, optionId)}
+              />
+            </Card>
+
+            <Card title="Keepsake" subtitle="Survives even if you die below">
+              <KeepsakePanel
+                candidates={getKeepsakeCandidates(state)}
+                selectedInstanceId={state.pendingKeepsakeInstanceId}
+                onSelect={setKeepsake}
+                onClear={clearKeepsake}
+              />
+            </Card>
+
+            <Card title="Insurance" subtitle="Returns one equipped piece to the stash if you die">
+              <InsurancePanel
+                candidates={player ? (Object.values(player.equipped).filter(Boolean) as ItemInstance[]) : []}
+                selectedInstanceId={state.pendingInsuredInstanceId}
+                getCost={getInsuranceCost}
+                gold={stash.gold}
+                onInsure={purchaseInsurance}
+                onCancel={cancelInsurance}
               />
             </Card>
           </>

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -40,7 +40,7 @@ import { getEnemy } from "../data/enemies";
 import { getAncestry } from "../data/ancestries";
 import { getClass } from "../data/classes";
 import { startCombat as startCombatBase, resolvePlayerAction, type CombatAction } from "../game/combat";
-import { applyAbandonPenalty, applyDeathPenalty, applyExtractionRewards, applyXpAndLevel, type DeathSummary, type ExtractionRewardSummary } from "../game/progression";
+import { applyExtractionRewards, applyXpAndLevel, resolveAbandonOutcome, resolveDeathOutcome, type DeathSummary, type ExtractionRewardSummary } from "../game/progression";
 import { appendRunSummary, buildRunSummary } from "../game/runSummary";
 import { getModifier, recalculateCharacterStats } from "../game/characterMath";
 import { THREAT_RULES } from "../game/constants";
@@ -78,7 +78,14 @@ import { initializeVillageProgression, upgradeNpcService as upgradeNpcServiceBas
 import { initializeQuestChainsForVillage, advanceQuestChainAfterQuestClaim } from "../game/questChains";
 import { craftRecipe as craftRecipeBase } from "../game/crafting";
 import { performServiceAction as performServiceActionBase } from "../game/services";
-import { purchaseRunPreparation as purchaseRunPreparationBase, applyRunPreparationsToRun } from "../game/runPreparation";
+import {
+  purchaseRunPreparation as purchaseRunPreparationBase,
+  applyRunPreparationsToRun,
+  purchaseInsurance as purchaseInsuranceBase,
+  cancelInsurance as cancelInsuranceBase,
+  setKeepsake as setKeepsakeBase,
+  clearKeepsake as clearKeepsakeBase
+} from "../game/runPreparation";
 import { applyQuestReward } from "../game/villageRewards";
 import {
   awardCharacterXp,
@@ -176,6 +183,10 @@ export interface GameStore {
   ) => void;
   purchaseRunPreparation: (npcId: string, optionId: string) => void;
   clearPendingRunPreparation: (preparedModifierId: string) => void;
+  purchaseInsurance: (itemInstanceId: string) => void;
+  cancelInsurance: () => void;
+  setKeepsake: (itemInstanceId: string) => void;
+  clearKeepsake: () => void;
   startDungeonRunWithPreparations: (params?: { biome?: import("../game/types").DungeonBiome; seed?: string }) => void;
 
   // v0.4 integration wrappers
@@ -405,6 +416,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
     run.raidInventory = s.preparedInventory ?? createEmptyInventory();
     run.loadoutSnapshot = collectLoadoutSnapshot(s.player);
     run.questProgressAtStart = captureQuestProgress(s.village, activeIds);
+    run.keepsakeInstanceId = resolveKeepsakeForRun(s, run.raidInventory);
+    run.insuredInstanceId = resolveInsuredForRun(s, s.player);
     const prepared = applyRunPreparationsToRun({
       run,
       character: s.player,
@@ -418,7 +431,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
       player: prepared.character,
       activeRun: run,
       preparedInventory: createEmptyInventory(),
-      pendingRunPreparations: (s.pendingRunPreparations ?? []).filter(prep => !prepared.appliedPreparations.some(applied => applied.id === prep.id))
+      pendingRunPreparations: (s.pendingRunPreparations ?? []).filter(prep => !prepared.appliedPreparations.some(applied => applied.id === prep.id)),
+      pendingKeepsakeInstanceId: undefined,
+      pendingInsuredInstanceId: undefined
     };
     set({ state: next, screen: "dungeon", lastRoomMessage: `You enter ${getBiome(run.biome).name}.` });
     persist(next);
@@ -433,6 +448,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
     run.raidInventory = s.preparedInventory ?? createEmptyInventory();
     run.loadoutSnapshot = collectLoadoutSnapshot(s.player);
     run.questProgressAtStart = captureQuestProgress(s.village, activeIds);
+    run.keepsakeInstanceId = resolveKeepsakeForRun(s, run.raidInventory);
+    run.insuredInstanceId = resolveInsuredForRun(s, s.player);
     const prepared = applyRunPreparationsToRun({
       run,
       character: s.player,
@@ -446,7 +463,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
       player: prepared.character,
       activeRun: run,
       preparedInventory: createEmptyInventory(),
-      pendingRunPreparations: (s.pendingRunPreparations ?? []).filter(prep => !prepared.appliedPreparations.some(applied => applied.id === prep.id))
+      pendingRunPreparations: (s.pendingRunPreparations ?? []).filter(prep => !prepared.appliedPreparations.some(applied => applied.id === prep.id)),
+      pendingKeepsakeInstanceId: undefined,
+      pendingInsuredInstanceId: undefined
     };
     set({ state: next, screen: "dungeon", lastRoomMessage: `You enter the ${run.biome} (${run.seed}).` });
     persist(next);
@@ -454,9 +473,12 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   abandonRun: () => {
     const s = get().state;
-    if (!s.activeRun) return;
-    const { run, summary } = applyAbandonPenalty(s.activeRun);
-    const player = s.player ? { ...s.player, hp: s.player.maxHp, wounded: undefined } : s.player;
+    if (!s.activeRun || !s.player) return;
+    const { run, player, stash, summary } = resolveAbandonOutcome({
+      run: s.activeRun,
+      player: s.player,
+      stash: s.stash
+    });
     const runSummary = buildRunSummary({
       run,
       village: s.village,
@@ -467,6 +489,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
     const next: GameState = {
       ...s,
       player,
+      stash,
       activeRun: undefined,
       completedRuns: [...s.completedRuns, run],
       lastRunSummary: runSummary,
@@ -1011,6 +1034,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
     nextRun.raidInventory = run.raidInventory;
     nextRun.loadoutSnapshot = run.loadoutSnapshot;
     nextRun.questProgressAtStart = run.questProgressAtStart;
+    nextRun.keepsakeInstanceId = run.keepsakeInstanceId;
+    nextRun.insuredInstanceId = run.insuredInstanceId;
     nextRun.xpGained = run.xpGained;
     nextRun.roomsVisitedBeforeDepth = (run.roomsVisitedBeforeDepth ?? 0) + run.visitedRoomIds.length;
     nextRun.roomsCompletedBeforeDepth = (run.roomsCompletedBeforeDepth ?? 0) + completedThisDepth;
@@ -1385,7 +1410,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
     const next: GameState = {
       ...s,
       preparedInventory: removeItem(s.preparedInventory, itemInstanceId, item.quantity),
-      stash: addItem(s.stash, item)
+      stash: addItem(s.stash, item),
+      pendingKeepsakeInstanceId: s.pendingKeepsakeInstanceId === itemInstanceId ? undefined : s.pendingKeepsakeInstanceId
     };
     set({ state: next, lastVillageMessage: `${item.name} returned to stash.` });
     persist(next);
@@ -1519,6 +1545,30 @@ export const useGameStore = create<GameStore>((set, get) => ({
       pendingRunPreparations: (s.pendingRunPreparations ?? []).filter(prep => prep.id !== preparedModifierId)
     };
     set({ state: next, lastVillageMessage: "Preparation cleared." });
+    persist(next);
+  },
+
+  purchaseInsurance: itemInstanceId => {
+    const result = purchaseInsuranceBase({ gameState: get().state, itemInstanceId });
+    set({ state: result.gameState, lastVillageMessage: result.message });
+    persist(result.gameState);
+  },
+
+  cancelInsurance: () => {
+    const next = cancelInsuranceBase(get().state);
+    set({ state: next, lastVillageMessage: "Insurance cancelled." });
+    persist(next);
+  },
+
+  setKeepsake: itemInstanceId => {
+    const result = setKeepsakeBase({ gameState: get().state, itemInstanceId });
+    set({ state: result.gameState, lastVillageMessage: result.message });
+    persist(result.gameState);
+  },
+
+  clearKeepsake: () => {
+    const next = clearKeepsakeBase(get().state);
+    set({ state: next, lastVillageMessage: "Keepsake cleared." });
     persist(next);
   },
 
@@ -1971,6 +2021,20 @@ function collectLoadoutSnapshot(player: Character): ItemInstance[] {
   ) as ItemInstance[];
 }
 
+function resolveKeepsakeForRun(state: GameState, raidInventory: Inventory): string | undefined {
+  const instanceId = state.pendingKeepsakeInstanceId;
+  if (!instanceId) return undefined;
+  const item = raidInventory.items.find(i => i.instanceId === instanceId);
+  return item && item.weight === 0 && item.quantity === 1 ? instanceId : undefined;
+}
+
+function resolveInsuredForRun(state: GameState, player: Character): string | undefined {
+  const instanceId = state.pendingInsuredInstanceId;
+  if (!instanceId) return undefined;
+  const equipped = Object.values(player.equipped).filter(Boolean) as ItemInstance[];
+  return equipped.some(item => item.instanceId === instanceId) ? instanceId : undefined;
+}
+
 function captureQuestProgress(village: VillageState | undefined, questIds: string[]): Record<string, number> {
   if (!village) return {};
   return Object.fromEntries(
@@ -2060,19 +2124,6 @@ function completeRoom(run: DungeonRun, roomId: string): DungeonRun {
   };
 }
 
-function recoverPlayerAfterDeath(player: Character, summary: DeathSummary): Character {
-  const lostIds = new Set(summary.itemsLost.map(item => item.instanceId));
-  const equipped = { ...player.equipped };
-  for (const slot of ["weapon", "offhand", "armor", "trinket1", "trinket2"] as const) {
-    const item = equipped[slot];
-    if (item && lostIds.has(item.instanceId)) {
-      equipped[slot] = undefined;
-    }
-  }
-  const recalculated = recalculatePlayer({ ...player, equipped, wounded: undefined });
-  return { ...recalculated, hp: recalculated.maxHp, wounded: undefined };
-}
-
 function rollCombatDrops(room: DungeonRoom, run: DungeonRun, rng: Rng): ItemInstance[] {
   const dropChance =
     room.type === "boss" ? 1 :
@@ -2104,8 +2155,11 @@ function finishRunWithDeath(
     run, type: "danger", now, roomId: run.currentRoomId,
     message: `${player.name} falls here. The dungeon keeps the raid pack.`
   });
-  const { run: deadRun, summary } = applyDeathPenalty(runWithLog);
-  const recoveredPlayer = recoverPlayerAfterDeath(player, summary);
+  const { run: deadRun, player: recoveredPlayer, stash, summary } = resolveDeathOutcome({
+    run: runWithLog,
+    player,
+    stash: s.stash
+  });
   const runSummary = buildRunSummary({
     run: deadRun,
     village: s.village,
@@ -2116,6 +2170,7 @@ function finishRunWithDeath(
   const next: GameState = {
     ...s,
     player: recoveredPlayer,
+    stash,
     activeRun: undefined,
     activeCombat: undefined,
     completedRuns: [...s.completedRuns, deadRun],

--- a/src/tests/deathCost.test.ts
+++ b/src/tests/deathCost.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import { applyDeathPenalty, resolveDeathOutcome } from "../game/progression";
+import { CharacterCreationService, createEmptyDraft } from "../game/characterCreation";
+import { generateDungeonRun } from "../game/dungeonGenerator";
+import { addItem, createEmptyInventory, instanceFromTemplateId } from "../game/inventory";
+import { createRng } from "../game/rng";
+import { defaultGameState, loadGame, saveGame } from "../game/save";
+import { SAVE_VERSION } from "../game/constants";
+import type { GameState } from "../game/types";
+
+function buildPlayer() {
+  let d = createEmptyDraft("death-cost");
+  d = CharacterCreationService.setName(d, "Tester");
+  d = CharacterCreationService.selectAncestry(d, "human");
+  d = CharacterCreationService.selectClass(d, "scout");
+  d = CharacterCreationService.rollAllAbilityScores(d);
+  d = CharacterCreationService.autoAssignScoresForClass(d);
+  d = CharacterCreationService.chooseStarterKit(d, "scout_bow_dagger");
+  return CharacterCreationService.finalizeCharacter(d).character;
+}
+
+describe("death cost", () => {
+  it("death loses the raid pack and all equipped gear", () => {
+    const run = generateDungeonRun({ seed: "death-cost-full" });
+    const rng = createRng("dc1");
+    run.raidInventory = addItem(run.raidInventory, instanceFromTemplateId("material_bone_dust", rng, 3));
+    run.raidInventory = { ...run.raidInventory, gold: 50 };
+    run.loadoutSnapshot = [
+      instanceFromTemplateId("weapon_short_sword", rng),
+      instanceFromTemplateId("trinket_pilgrim_charm", rng)
+    ];
+    const { run: dead, summary } = applyDeathPenalty(run);
+    expect(dead.status).toBe("dead");
+    expect(dead.raidInventory.items).toHaveLength(0);
+    expect(dead.raidInventory.gold).toBe(0);
+    expect(dead.loadoutSnapshot).toHaveLength(0);
+    expect(summary.raidItemsLost).toHaveLength(1);
+    expect(summary.gearLost).toHaveLength(2);
+    expect(summary.goldLost).toBe(50);
+  });
+
+  it("quest items always survive death", () => {
+    const run = generateDungeonRun({ seed: "death-cost-quest" });
+    const rng = createRng("dc2");
+    const questItem = instanceFromTemplateId("quest_lost_sign", rng);
+    run.raidInventory = addItem(run.raidInventory, questItem);
+    run.raidInventory = addItem(run.raidInventory, instanceFromTemplateId("material_bone_dust", rng, 1));
+
+    const { run: dead, summary } = applyDeathPenalty(run);
+    expect(dead.raidInventory.items).toHaveLength(0);
+    expect(summary.questItemsSaved.map(i => i.instanceId)).toEqual([questItem.instanceId]);
+    expect(summary.raidItemsLost.some(i => i.instanceId === questItem.instanceId)).toBe(false);
+    expect(summary.itemsLost.some(i => i.instanceId === questItem.instanceId)).toBe(false);
+  });
+
+  it("a designated keepsake survives death via resolveDeathOutcome", () => {
+    const player = buildPlayer();
+    const run = generateDungeonRun({ seed: "death-cost-keepsake" });
+    const rng = createRng("dc3");
+    const keepsake = instanceFromTemplateId("trinket_minor_ward", rng); // weight 0
+    run.raidInventory = addItem(run.raidInventory, keepsake);
+    run.raidInventory = addItem(run.raidInventory, instanceFromTemplateId("material_bone_dust", rng, 1));
+    run.keepsakeInstanceId = keepsake.instanceId;
+
+    const { stash, summary } = resolveDeathOutcome({ run, player, stash: createEmptyInventory() });
+    expect(summary.keepsakeSaved?.instanceId).toBe(keepsake.instanceId);
+    expect(stash.items.some(i => i.instanceId === keepsake.instanceId)).toBe(true);
+  });
+
+  it("a non-weightless item cannot be a keepsake", () => {
+    const run = generateDungeonRun({ seed: "death-cost-keepsake-invalid" });
+    const rng = createRng("dc3b");
+    const heavyItem = instanceFromTemplateId("weapon_short_sword", rng); // has weight
+    run.raidInventory = addItem(run.raidInventory, heavyItem);
+    run.keepsakeInstanceId = heavyItem.instanceId;
+
+    const { summary } = applyDeathPenalty(run);
+    expect(summary.keepsakeSaved).toBeUndefined();
+    expect(summary.raidItemsLost.some(i => i.instanceId === heavyItem.instanceId)).toBe(true);
+  });
+
+  it("insurance returns exactly the insured piece to the stash and unequips it", () => {
+    const player = buildPlayer();
+    const insuredWeapon = player.equipped.weapon!;
+    const otherGear = player.equipped.offhand;
+
+    const run = generateDungeonRun({ seed: "death-cost-insurance" });
+    run.loadoutSnapshot = [insuredWeapon, ...(otherGear ? [otherGear] : [])];
+    run.insuredInstanceId = insuredWeapon.instanceId;
+
+    const { player: recoveredPlayer, stash, summary } = resolveDeathOutcome({
+      run,
+      player,
+      stash: createEmptyInventory()
+    });
+
+    expect(summary.insuranceReturned?.instanceId).toBe(insuredWeapon.instanceId);
+    expect(summary.gearLost.some(i => i.instanceId === insuredWeapon.instanceId)).toBe(false);
+    expect(stash.items.filter(i => i.instanceId === insuredWeapon.instanceId)).toHaveLength(1);
+    expect(recoveredPlayer.equipped.weapon).toBeUndefined();
+    if (otherGear) {
+      expect(recoveredPlayer.equipped.offhand).toBeUndefined();
+      expect(stash.items.some(i => i.instanceId === otherGear.instanceId)).toBe(false);
+    }
+  });
+
+  it("loads an old save shape lacking keepsake/insurance fields on the active run", () => {
+    localStorage.clear();
+    const run = generateDungeonRun({ seed: "death-cost-legacy" });
+    const legacy = {
+      ...defaultGameState(),
+      version: 3,
+      activeRun: run
+    } as unknown as GameState;
+    // Simulate a pre-feature save: no keepsakeInstanceId/insuredInstanceId/pending* fields at all.
+    delete (legacy.activeRun as unknown as Record<string, unknown>).keepsakeInstanceId;
+    delete (legacy.activeRun as unknown as Record<string, unknown>).insuredInstanceId;
+
+    saveGame(legacy);
+    const loaded = loadGame();
+    expect(loaded?.version).toBe(SAVE_VERSION);
+    expect(loaded?.activeRun?.keepsakeInstanceId).toBeUndefined();
+    expect(loaded?.activeRun?.insuredInstanceId).toBeUndefined();
+    expect(loaded?.pendingKeepsakeInstanceId).toBeUndefined();
+    expect(loaded?.pendingInsuredInstanceId).toBeUndefined();
+  });
+
+  it("round-trips keepsake/insurance fields through save and load", () => {
+    localStorage.clear();
+    const rng = createRng("death-cost-roundtrip");
+    const run = generateDungeonRun({ seed: "death-cost-roundtrip" });
+    const keepsake = instanceFromTemplateId("trinket_minor_ward", rng);
+    run.raidInventory = addItem(run.raidInventory, keepsake);
+    run.keepsakeInstanceId = keepsake.instanceId;
+    run.insuredInstanceId = "some-weapon-instance-id";
+
+    const state: GameState = {
+      ...defaultGameState(),
+      activeRun: run,
+      pendingKeepsakeInstanceId: "pending-keepsake-id",
+      pendingInsuredInstanceId: "pending-insured-id"
+    };
+
+    saveGame(state);
+    const loaded = loadGame();
+    expect(loaded?.activeRun?.keepsakeInstanceId).toBe(keepsake.instanceId);
+    expect(loaded?.activeRun?.insuredInstanceId).toBe("some-weapon-instance-id");
+    expect(loaded?.pendingKeepsakeInstanceId).toBe("pending-keepsake-id");
+    expect(loaded?.pendingInsuredInstanceId).toBe("pending-insured-id");
+  });
+});

--- a/src/tests/runPreparation.test.ts
+++ b/src/tests/runPreparation.test.ts
@@ -4,8 +4,32 @@ import { generateVillage } from "../game/npcGenerator";
 import { createRng } from "../game/rng";
 import { initializeVillageProgression } from "../game/villageProgression";
 import { generateDungeonRun } from "../game/dungeonGenerator";
-import { getAvailableRunPreparationOptions, purchaseRunPreparation, applyRunPreparationsToRun } from "../game/runPreparation";
+import {
+  getAvailableRunPreparationOptions,
+  purchaseRunPreparation,
+  applyRunPreparationsToRun,
+  getInsuranceCost,
+  canPurchaseInsurance,
+  purchaseInsurance,
+  getKeepsakeCandidates,
+  canDesignateKeepsake,
+  setKeepsake
+} from "../game/runPreparation";
+import { addItem } from "../game/inventory";
+import { instanceFromTemplateId } from "../game/inventory";
+import { CharacterCreationService, createEmptyDraft } from "../game/characterCreation";
 import type { Character } from "../game/types";
+
+function buildPlayer() {
+  let d = createEmptyDraft("prep-test");
+  d = CharacterCreationService.setName(d, "Tester");
+  d = CharacterCreationService.selectAncestry(d, "human");
+  d = CharacterCreationService.selectClass(d, "scout");
+  d = CharacterCreationService.rollAllAbilityScores(d);
+  d = CharacterCreationService.autoAssignScoresForClass(d);
+  d = CharacterCreationService.chooseStarterKit(d, "scout_bow_dagger");
+  return CharacterCreationService.finalizeCharacter(d).character;
+}
 
 describe("run preparation", () => {
   it("lists unlocked preparations and purchases one", () => {
@@ -50,5 +74,50 @@ describe("run preparation", () => {
     expect(result.run.raidInventory.items[0]?.templateId).toBe("consumable_small_draught");
     expect(result.character.derivedStats.carryCapacity).toBe(25);
     expect(result.appliedPreparations.every(prep => prep.consumed)).toBe(true);
+  });
+
+  it("prices insurance at a fraction of item value and charges gold on purchase", () => {
+    const player = buildPlayer();
+    const weapon = player.equipped.weapon!;
+    const cost = getInsuranceCost(weapon);
+    expect(cost).toBe(Math.ceil(weapon.value * 0.3));
+
+    const gameState = { ...defaultGameState(), player, stash: { items: [], gold: cost + 10, materials: {} } };
+    const gate = canPurchaseInsurance({ gameState, itemInstanceId: weapon.instanceId });
+    expect(gate.canPurchase).toBe(true);
+
+    const result = purchaseInsurance({ gameState, itemInstanceId: weapon.instanceId });
+    expect(result.success).toBe(true);
+    expect(result.gameState.pendingInsuredInstanceId).toBe(weapon.instanceId);
+    expect(result.gameState.stash.gold).toBe(10);
+  });
+
+  it("refuses to insure a second item once one is already insured", () => {
+    const player = buildPlayer();
+    const weapon = player.equipped.weapon!;
+    const gameState = {
+      ...defaultGameState(),
+      player,
+      stash: { items: [], gold: 1000, materials: {} },
+      pendingInsuredInstanceId: weapon.instanceId
+    };
+    const otherSlotItem = Object.values(player.equipped).find(item => item && item.instanceId !== weapon.instanceId);
+    const gate = canPurchaseInsurance({ gameState, itemInstanceId: otherSlotItem?.instanceId ?? weapon.instanceId });
+    expect(gate.canPurchase).toBe(false);
+  });
+
+  it("only allows a weightless packed item to be designated as a keepsake", () => {
+    const rng = createRng("keepsake-test");
+    const weightless = instanceFromTemplateId("trinket_minor_ward", rng);
+    const heavy = instanceFromTemplateId("weapon_short_sword", rng);
+    let gameState = defaultGameState();
+    gameState = { ...gameState, preparedInventory: addItem(addItem(gameState.preparedInventory, weightless), heavy) };
+
+    expect(getKeepsakeCandidates(gameState).map(i => i.instanceId)).toEqual([weightless.instanceId]);
+    expect(canDesignateKeepsake({ gameState, itemInstanceId: heavy.instanceId }).canDesignate).toBe(false);
+
+    const result = setKeepsake({ gameState, itemInstanceId: weightless.instanceId });
+    expect(result.success).toBe(true);
+    expect(result.gameState.pendingKeepsakeInstanceId).toBe(weightless.instanceId);
   });
 });

--- a/src/tests/saveMigrationV4.test.ts
+++ b/src/tests/saveMigrationV4.test.ts
@@ -98,7 +98,8 @@ describe("save migration v4", () => {
       questProgress: [],
       questsCompleted: [],
       questRewards: [stripV4ItemFields(instanceFromTemplateId("material_bone_dust", rng))],
-      unlocksApplied: []
+      unlocksApplied: [],
+      questItemsSaved: []
     };
 
     const legacy = {


### PR DESCRIPTION
Closes #2.

- Death loses raid pack + all equipped gear (now explicit); quest items always survive death and abandon, returned to stash
- Keepsake: one non-stacked weight-0 item designated at run prep survives death
- Insurance: one equipped piece insurable for ceil(value*0.3) gold, returned to stash on death
- Run summary shows What Survived for death/abandon
- Pure resolvers (resolveDeathOutcome/resolveAbandonOutcome) with store as thin wrapper; no SAVE_VERSION bump (optional fields, round-trip + old-shape tests)

214/214 tests (10 new), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)