### PR TITLE
Narrative-first dungeon screen: single story column, inline passage choices, demoted map

### DIFF
--- a/src/components/DungeonLog.tsx
+++ b/src/components/DungeonLog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { DungeonLogEntry } from "../game/types";
 
 export interface DungeonLogProps {
@@ -6,10 +6,58 @@ export interface DungeonLogProps {
   limit?: number;
 }
 
+// Display-only cleanup. The stored log entries are never mutated — we only
+// reshape what gets rendered:
+//   1. "You enter X." / "You step back into X." immediately followed by the
+//      threat system's generic "You press deeper into the dungeon." reads as
+//      two near-identical lines about the same beat. Fold the second into the
+//      first, keeping any extra transition text ("The halls begin to stir.").
+//   2. Raw mechanics suffixes like "(+3)" or "(+5 strain)" are stripped —
+//      the HUD meters convey the numbers now, prose doesn't need to.
+const ENTER_ROOM_RE = /^You (?:enter|step back into) /;
+const PRESS_DEEPER_RE = /^You press deeper into the dungeon\.?\s*(.*)$/;
+const MECHANIC_SUFFIX_RE = /\s*\([+-]?\d+(?:\s+[a-zA-Z]+)?\)/g;
+
+interface DisplayEntry {
+  id: string;
+  type: DungeonLogEntry["type"];
+  message: string;
+}
+
+function cleanMessage(message: string): string {
+  return message.replace(MECHANIC_SUFFIX_RE, "").replace(/\s+([.,!?])/g, "$1").trim();
+}
+
+function collapseEntries(entries: DungeonLogEntry[]): DisplayEntry[] {
+  const result: DisplayEntry[] = [];
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const next = entries[i + 1];
+    if (
+      ENTER_ROOM_RE.test(entry.message) &&
+      next &&
+      next.type === "threat" &&
+      PRESS_DEEPER_RE.test(next.message)
+    ) {
+      const extra = next.message.match(PRESS_DEEPER_RE)?.[1]?.trim();
+      result.push({
+        id: entry.id,
+        type: entry.type,
+        message: extra ? `${cleanMessage(entry.message)} ${cleanMessage(extra)}` : cleanMessage(entry.message)
+      });
+      i++; // skip the folded-in threat entry
+      continue;
+    }
+    result.push({ id: entry.id, type: entry.type, message: cleanMessage(entry.message) });
+  }
+  return result;
+}
+
 export function DungeonLog({ entries, limit = 50 }: DungeonLogProps) {
   const listRef = useRef<HTMLUListElement | null>(null);
   const tail = entries.slice(Math.max(0, entries.length - limit));
-  const latestId = tail[tail.length - 1]?.id;
+  const displayEntries = useMemo(() => collapseEntries(tail), [tail]);
+  const latestId = displayEntries[displayEntries.length - 1]?.id;
 
   useEffect(() => {
     const el = listRef.current;
@@ -17,17 +65,17 @@ export function DungeonLog({ entries, limit = 50 }: DungeonLogProps) {
     el.scrollTop = el.scrollHeight;
   }, [latestId]);
 
-  if (tail.length === 0) {
+  if (displayEntries.length === 0) {
     return <p className="muted small dungeon-log-empty">The dungeon is still.</p>;
   }
 
   // Older entries fade out the further they are from the latest. The 6 most
   // recent each get progressively dimmer; anything older settles at the
   // dimmest tier.
-  const total = tail.length;
+  const total = displayEntries.length;
   return (
     <ul ref={listRef} className="dungeon-log dungeon-log-diegetic" aria-label="Recent dungeon events">
-      {tail.map((entry, idx) => {
+      {displayEntries.map((entry, idx) => {
         const fromLatest = total - 1 - idx;
         const recencyClass = fromLatest === 0
           ? "dungeon-log-now"

--- a/src/index.css
+++ b/src/index.css
@@ -852,6 +852,9 @@ code { font-family: ui-monospace, Menlo, monospace; color: var(--accent-2); }
   gap: 10px;
   border-bottom: 1px solid transparent;
   padding-bottom: 4px;
+  max-width: 70ch;
+  margin: 0 auto;
+  width: 100%;
 }
 .dungeon-screen-lower .dungeon-header { border-bottom-color: rgba(200, 155, 60, 0.18); }
 .dungeon-screen-deep .dungeon-header { border-bottom-color: rgba(199, 80, 80, 0.24); }
@@ -875,6 +878,9 @@ code { font-family: ui-monospace, Menlo, monospace; color: var(--accent-2); }
   background: var(--bg-1);
   font-size: 0.84rem;
   color: var(--text-dim);
+  max-width: 70ch;
+  margin: 0 auto;
+  width: 100%;
 }
 .dungeon-hud-hp { display: flex; align-items: center; gap: 8px; }
 .dungeon-hud-label {
@@ -890,43 +896,130 @@ code { font-family: ui-monospace, Menlo, monospace; color: var(--accent-2); }
 }
 .dungeon-hud-urgent { color: var(--warn); font-weight: 600; }
 
-.dungeon-grid {
-  display: grid;
-  grid-template-columns: 2fr 1fr;
-  grid-template-areas: "current adj" "map log";
-  gap: 12px;
-  flex: 1 1 0;
-  min-height: 0;
-  align-items: stretch;
-}
-.dungeon-grid .card:nth-child(1) { grid-area: current; }
-.dungeon-grid .card:nth-child(2) { grid-area: adj; }
-.dungeon-grid .card:nth-child(3) { grid-area: map; }
-.dungeon-grid .card:nth-child(4) { grid-area: log; }
-
-.dungeon-grid-noexits {
-  grid-template-columns: 1.4fr 1fr;
-  grid-template-areas: "current map" "current log";
-  align-items: stretch;
-}
-.dungeon-grid-noexits .card:nth-child(1) { grid-area: current; }
-.dungeon-grid-noexits .card:nth-child(2) { grid-area: map; }
-.dungeon-grid-noexits .card:nth-child(3) { grid-area: log; }
-
-.dungeon-grid > .card {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  max-height: 100%;
-  margin-bottom: 0;
-}
-.dungeon-grid > .card > .card-body {
+/* Narrative column — the dungeon screen's primary reading surface.
+   One scroll region below the sticky header/HUD; the column itself stays
+   centered and capped to a comfortable reading measure. */
+.narrative-scroll {
   flex: 1 1 0;
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
-  padding-right: 4px;
 }
+.narrative-column {
+  max-width: 70ch;
+  margin: 0 auto;
+  width: 100%;
+  padding: 4px 2px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dungeon-header-biome { display: block; margin-top: 2px; }
+
+.room-hero { margin-bottom: 4px; }
+.room-hero-meta {
+  display: block;
+  font-size: 0.74rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+.room-hero-title {
+  font-size: 2rem;
+  margin: 0 0 8px;
+}
+.room-hero-danger .room-hero-title { color: var(--danger); }
+.room-hero-prose {
+  font-size: 1.08rem;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+.passages-block { margin-top: 14px; }
+.passages-heading {
+  font-size: 0.9rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+  margin: 0 0 8px;
+}
+.passages-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.passage-choice {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 14px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font: inherit;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 100ms ease, background 100ms ease;
+}
+.passage-choice:hover { border-color: var(--accent); background: var(--bg-2); }
+.passage-direction {
+  flex: 0 0 auto;
+  min-width: 4.5em;
+  font-size: 0.76rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+}
+.passage-direction::after { content: "\2014"; margin-left: 8px; color: var(--text-muted); }
+.passage-desc { color: var(--text-dim); font-style: italic; }
+
+.dungeon-secondary-toggles {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+.secondary-toggle {
+  padding: 6px 12px;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font: inherit;
+  font-size: 0.82rem;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: border-color 100ms ease, color 100ms ease;
+}
+.secondary-toggle:hover { border-color: var(--accent); color: var(--text); }
+
+.chart-panel,
+.log-panel,
+.gear-risk-panel {
+  margin-top: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: var(--bg-1);
+}
+.chart-panel-header,
+.log-panel-header,
+.gear-risk-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+.chart-panel-header h3,
+.log-panel-header h3,
+.gear-risk-panel-header h3 { margin: 0; font-size: 1rem; }
 
 .dungeon-header-mood {
   color: var(--text-dim);
@@ -1174,9 +1267,13 @@ button.map-room:hover {
 /* Combat — scene layout */
 .combat-screen {
   display: grid;
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: auto auto 1fr auto;
   gap: 12px;
   padding: 14px 24px 18px;
+  max-width: 70ch;
+  margin: 0 auto;
+  width: 100%;
+  min-height: 0;
 }
 .combat-header {
   display: flex;
@@ -1196,17 +1293,16 @@ button.map-room:hover {
 .combat-header-state .danger { color: var(--danger); }
 
 .combat-stage {
-  display: grid;
-  grid-template-columns: 1fr 280px;
-  gap: 14px;
-  align-items: start;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: stretch;
 }
 .combat-enemy-row {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(150px, 1fr);
+  display: flex;
+  flex-wrap: wrap;
   gap: 10px;
-  padding: 18px 16px;
+  padding: 14px 16px;
   border: 1px solid var(--warm-line);
   border-radius: 10px;
   background:
@@ -1220,6 +1316,8 @@ button.map-room:hover {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  flex: 1 1 150px;
+  max-width: 220px;
   padding: 10px 12px;
   background: var(--bg-2);
   border: 1px solid var(--line);
@@ -1280,6 +1378,7 @@ button.combat-enemy:hover { border-color: var(--accent); background: var(--bg-3)
   background: var(--bg-1);
   border: 1px solid var(--line);
   border-radius: 8px;
+  width: 100%;
 }
 .combat-player-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
 .combat-player-stats { letter-spacing: 0.02em; }
@@ -1383,17 +1482,23 @@ button.combat-enemy:hover { border-color: var(--accent); background: var(--bg-3)
 .combat-log-panel {
   border: 1px solid var(--line);
   border-radius: 6px;
-  padding: 8px 12px;
+  padding: 8px 14px;
   background: var(--bg-1);
-  max-height: 180px;
+  min-height: 0;
   overflow-y: auto;
+  font-family: ui-serif, Georgia, serif;
 }
-.combat-log { list-style: none; padding-left: 0; margin: 0; font-size: 0.9rem; color: var(--text-dim); }
+.combat-log { list-style: none; padding-left: 0; margin: 0; font-size: 0.95rem; color: var(--text-dim); }
 .combat-log li {
-  padding: 3px 0;
+  padding: 4px 0;
   border-bottom: 1px dashed rgba(255,255,255,0.05);
 }
-.combat-log li:last-child { color: var(--text); }
+.combat-log li:last-child {
+  color: var(--text);
+  font-weight: 600;
+  font-size: 1.08em;
+  border-bottom: none;
+}
 
 .combat-actions-bar {
   display: flex;
@@ -1860,6 +1965,15 @@ button.combat-enemy:hover { border-color: var(--accent); background: var(--bg-3)
   padding: 8px 10px;
   color: var(--accent-2);
   font-weight: 700;
+}
+/* The dev panel docks fixed to the bottom-right corner. Reserve clear space
+   under the game's own bottom-pinned action bars so its (collapsed) summary
+   strip never sits on top of a button the player needs to click. */
+.app-root:has(> .dev-panel) .combat-actions-bar {
+  padding-bottom: 52px;
+}
+.app-root:has(> .dev-panel) .narrative-column {
+  padding-bottom: 64px;
 }
 .dev-panel-body {
   border-top: 1px solid var(--line);

--- a/src/screens/DungeonScreen.tsx
+++ b/src/screens/DungeonScreen.tsx
@@ -1,5 +1,5 @@
+import { useState } from "react";
 import { Button } from "../components/Button";
-import { Card } from "../components/Card";
 import { DungeonLog } from "../components/DungeonLog";
 import { EventChoicePanel } from "../components/EventChoicePanel";
 import { ExtractionPanel } from "../components/ExtractionPanel";
@@ -13,6 +13,7 @@ import { getBiome } from "../data/biomes";
 import { calculateInventoryWeight } from "../game/inventory";
 import { floorHasPendingLoot, hasPendingLoot } from "../game/pendingLoot";
 import { SEARCH_RULES } from "../game/constants";
+import { getDangerBand } from "../game/scouting";
 import type { ActiveTrap, DungeonRoom, DungeonRun, RoomSignTag, ScoutedRoomInfo } from "../game/types";
 import type { ItemWithV4Fields } from "../components/v04UiTypes";
 import { getTrapTemplate } from "../data/trapTables";
@@ -65,6 +66,8 @@ export function DungeonScreen() {
   const abandon = useGameStore(s => s.abandonRun);
   const lastMessage = useGameStore(s => s.lastRoomMessage);
   const engage = useGameStore(s => s.engageCurrentRoomCombat);
+  const [showMap, setShowMap] = useState(false);
+  const [showLog, setShowLog] = useState(false);
 
   if (!run || !player) return <div className="screen">No active run.</div>;
   const current = getRoomById(run.roomGraph, run.currentRoomId);
@@ -91,6 +94,10 @@ export function DungeonScreen() {
       : "Search";
   const depthTone = run.tier >= 7 ? "deep" : run.tier >= 4 ? "lower" : "upper";
 
+  const passageRooms = current.connectedRoomIds
+    .map(id => getRoomById(run.roomGraph, id))
+    .filter((room): room is DungeonRoom => Boolean(room));
+
   return (
     <div className={`screen dungeon-screen dungeon-screen-${depthTone}`}>
       {lowHp && <div className="low-hp-vignette" aria-hidden="true" />}
@@ -99,8 +106,7 @@ export function DungeonScreen() {
           <span className="dungeon-header-eyebrow" title={`Seed: ${run.seed}`}>
             Depth {run.tier} · {biome.name}
           </span>
-          <h2>{current.title}</h2>
-          <p className="muted">{biome.description}</p>
+          <span className="dungeon-header-biome muted small">{biome.description}</span>
         </div>
         <div className="dungeon-actions">
           <Button variant="danger" onClick={() => {
@@ -127,9 +133,16 @@ export function DungeonScreen() {
         <span className="dungeon-hud-chip"><em>Uncharted</em> {unchartedRooms}</span>
       </div>
 
-      <div className="dungeon-grid dungeon-grid-noexits">
-        <Card title={current.title} subtitle={`${TYPE_LABELS[current.type] ?? current.type} · Danger ${current.dangerRating} · ${exitCount}/4 exits`} variant={current.dangerRating > 2 ? "danger" : "default"}>
-          <p>{current.description}</p>
+      <div className="narrative-scroll">
+        <div className="narrative-column">
+          <div className={`room-hero ${current.dangerRating > 2 ? "room-hero-danger" : ""}`}>
+            <span className="room-hero-meta">
+              {TYPE_LABELS[current.type] ?? current.type} · Danger {current.dangerRating} · {exitCount}/4 exits
+            </span>
+            <h1 className="room-hero-title">{current.title}</h1>
+            <p className="room-hero-prose">{current.description}</p>
+          </div>
+
           {current.trapId && <p className="warn">Trap detected: {current.trapId}</p>}
           {lastMessage && <p className="msg">{lastMessage}</p>}
 
@@ -179,6 +192,7 @@ export function DungeonScreen() {
             </>
             )}
           </div>
+
           {hasPendingLoot(current) &&
             !(current.activeEvent && !current.activeEvent.resolved) &&
             !(current.extraction && current.extraction.state === "charging") && (
@@ -203,31 +217,104 @@ export function DungeonScreen() {
               onContinue={continueExtract}
             />
           )}
-        </Card>
 
-        <Card title="Dungeon Map" subtitle={`${run.visitedRoomIds.length}/${run.roomGraph.length} rooms charted · Hover for intel`}>
-          <DungeonMap run={run} current={current} onMove={moveToRoom} />
-        </Card>
+          <section className="passages-block" aria-label="Passages">
+            <h3 className="passages-heading">Passages</h3>
+            {passageRooms.length === 0 ? (
+              <p className="muted small">No passages lead onward from here.</p>
+            ) : (
+              <ul className="passages-list">
+                {passageRooms.map(room => {
+                  const direction = getDirectionLabel(current, room);
+                  const isVisited = run.visitedRoomIds.includes(room.id);
+                  const intel = run.knownRoomIntel[room.id];
+                  return (
+                    <li key={room.id}>
+                      <button
+                        type="button"
+                        className="passage-choice"
+                        onClick={() => moveToRoom(room.id)}
+                      >
+                        <span className="passage-direction">{direction}</span>
+                        <span className="passage-desc">{describePassage(room, isVisited, intel)}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </section>
 
-        <Card title="Dungeon Log" subtitle={`${run.dungeonLog.length} event${run.dungeonLog.length === 1 ? "" : "s"}`}>
-          <DungeonLog entries={run.dungeonLog} />
-        </Card>
+          <div className="dungeon-secondary-toggles">
+            <button type="button" className="secondary-toggle" onClick={() => setShowMap(v => !v)}>
+              {showMap ? "Hide Chart" : "Chart"}
+            </button>
+            <button type="button" className="secondary-toggle" onClick={() => setShowLog(v => !v)}>
+              {showLog ? "Hide Log" : "Log"} <span className="muted small">({run.dungeonLog.length})</span>
+            </button>
+          </div>
 
-        {riskyItems.length > 0 && (
-          <Card title="Gear Risk" subtitle="Visible item states affecting this delve">
-            <ul className="risk-item-list">
-              {riskyItems.map(item => (
-                <li key={item!.instanceId}>
-                  <strong>{item!.name}</strong>
-                  <GearRiskBadge states={(item as ItemWithV4Fields).states} />
-                </li>
-              ))}
-            </ul>
-          </Card>
-        )}
+          {showMap && (
+            <section className="chart-panel" aria-label="Dungeon map">
+              <header className="chart-panel-header">
+                <h3>Dungeon Map</h3>
+                <span className="muted small">{run.visitedRoomIds.length}/{run.roomGraph.length} rooms charted · Hover for intel</span>
+              </header>
+              <DungeonMap run={run} current={current} onMove={moveToRoom} />
+            </section>
+          )}
+
+          {showLog && (
+            <section className="log-panel" aria-label="Dungeon log">
+              <header className="log-panel-header">
+                <h3>Dungeon Log</h3>
+                <span className="muted small">{run.dungeonLog.length} event{run.dungeonLog.length === 1 ? "" : "s"}</span>
+              </header>
+              <DungeonLog entries={run.dungeonLog} />
+            </section>
+          )}
+
+          {riskyItems.length > 0 && (
+            <section className="gear-risk-panel" aria-label="Gear risk">
+              <header className="gear-risk-panel-header">
+                <h3>Gear Risk</h3>
+                <span className="muted small">Visible item states affecting this delve</span>
+              </header>
+              <ul className="risk-item-list">
+                {riskyItems.map(item => (
+                  <li key={item!.instanceId}>
+                    <strong>{item!.name}</strong>
+                    <GearRiskBadge states={(item as ItemWithV4Fields).states} />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
       </div>
     </div>
   );
+}
+
+function describePassage(
+  room: DungeonRoom,
+  isVisited: boolean,
+  intel?: ScoutedRoomInfo
+): string {
+  if (isVisited) {
+    const band = getDangerBand(room.dangerRating);
+    return `${TYPE_LABELS[room.type] ?? room.type}, danger ${(DANGER_BAND_LABELS[band] ?? band).toLowerCase()}`;
+  }
+  if (!intel) return "an unscouted passage";
+  if (intel.shownType) return `${TYPE_LABELS[intel.shownType] ?? intel.shownType} passage`;
+  if (intel.likelyTypes.length > 0) {
+    const names = intel.likelyTypes.map(t => TYPE_LABELS[t] ?? t).slice(0, 2);
+    return `maybe ${names.join(" or ")}`;
+  }
+  if (intel.dangerBand !== "unknown") {
+    return `signs of ${(DANGER_BAND_LABELS[intel.dangerBand] ?? intel.dangerBand).toLowerCase()} danger`;
+  }
+  return "an unscouted passage";
 }
 
 function canStillSearch(room: DungeonRoom): boolean {


### PR DESCRIPTION
Closes #3.

- DungeonScreen: single centered 70ch narrative column — prose leads, event/loot/extraction panels inline, movement as full-width Passages choices with visible intel (direction + scouted danger), map and log demoted to collapsed Chart/Log toggles
- CombatScreen: void fixed via grid rows (log now fills the middle, latest line emphasized), 70ch cap
- DungeonLog: display-side dedupe of enter/press-deeper pairs; raw mechanic suffixes like "(+3)" stripped (meter conveys numbers now)
- DevPanel no longer overlaps action buttons

Typecheck + 204/204 tests. Visual QA to be done on this PR before merge (worker verified by JSX diff; preview could not bind to worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)