### PR TITLE
Replace native confirm() dialogs with in-world ConfirmDialog

### DIFF
--- a/src/components/ConfirmDialog.css
+++ b/src/components/ConfirmDialog.css
@@ -1,0 +1,89 @@
+.confirm-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(8, 8, 10, 0.65);
+  animation: confirm-dialog-fade-in 150ms ease-out;
+}
+
+.confirm-dialog-panel {
+  width: min(420px, calc(100vw - 32px));
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 24px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+  animation: confirm-dialog-scale-in 150ms ease-out;
+}
+
+.confirm-dialog-title {
+  margin: 0 0 12px;
+  font-family: ui-serif, Georgia, serif;
+  color: var(--text);
+  font-size: 1.25rem;
+  letter-spacing: 0.01em;
+}
+
+.confirm-dialog-body {
+  margin: 0 0 20px;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+
+.confirm-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.confirm-dialog-btn {
+  font-family: inherit;
+  font-size: 0.95rem;
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--line);
+  background: var(--bg-2);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.confirm-dialog-btn:hover {
+  border-color: var(--accent);
+}
+
+.confirm-dialog-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.confirm-dialog-btn-confirm {
+  background: var(--bg-3);
+  border-color: var(--accent);
+  color: var(--accent-2);
+}
+
+.confirm-dialog-btn-danger {
+  background: var(--bg-3);
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+@keyframes confirm-dialog-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes confirm-dialog-scale-in {
+  from { opacity: 0; transform: scale(0.96); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .confirm-dialog-backdrop,
+  .confirm-dialog-panel {
+    animation: none;
+  }
+}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from "react";
+import "./ConfirmDialog.css";
+
+interface ConfirmDialogProps {
+  title: string;
+  body: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  danger?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  title,
+  body,
+  confirmLabel,
+  cancelLabel,
+  danger,
+  onConfirm,
+  onCancel
+}: ConfirmDialogProps) {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const titleId = useRef(`confirm-dialog-title-${Math.random().toString(36).slice(2)}`).current;
+
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    cancelRef.current?.focus();
+
+    return () => {
+      previouslyFocused?.focus?.();
+    };
+  }, []);
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onCancel();
+      return;
+    }
+    if (event.key === "Tab") {
+      const focusables = [cancelRef.current, confirmRef.current].filter(Boolean) as HTMLElement[];
+      if (focusables.length === 0) return;
+      const currentIndex = focusables.indexOf(document.activeElement as HTMLElement);
+      event.preventDefault();
+      const nextIndex = event.shiftKey
+        ? (currentIndex - 1 + focusables.length) % focusables.length
+        : (currentIndex + 1) % focusables.length;
+      focusables[nextIndex].focus();
+    }
+  }
+
+  return (
+    <div className="confirm-dialog-backdrop" onClick={onCancel}>
+      <div
+        className="confirm-dialog-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onClick={event => event.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        <h2 id={titleId} className="confirm-dialog-title">{title}</h2>
+        <p className="confirm-dialog-body">{body}</p>
+        <div className="confirm-dialog-actions">
+          <button
+            ref={cancelRef}
+            type="button"
+            className="confirm-dialog-btn confirm-dialog-btn-cancel"
+            onClick={onCancel}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            className={`confirm-dialog-btn confirm-dialog-btn-confirm${danger ? " confirm-dialog-btn-danger" : ""}`}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/screens/DungeonScreen.tsx
+++ b/src/screens/DungeonScreen.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Button } from "../components/Button";
+import { ConfirmDialog } from "../components/ConfirmDialog";
 import { DungeonLog } from "../components/DungeonLog";
 import { EventChoicePanel } from "../components/EventChoicePanel";
 import { ExtractionPanel } from "../components/ExtractionPanel";
@@ -68,6 +69,8 @@ export function DungeonScreen() {
   const engage = useGameStore(s => s.engageCurrentRoomCombat);
   const [showMap, setShowMap] = useState(false);
   const [showLog, setShowLog] = useState(false);
+  const [showAbandonConfirm, setShowAbandonConfirm] = useState(false);
+  const [showDescendConfirm, setShowDescendConfirm] = useState(false);
 
   if (!run || !player) return <div className="screen">No active run.</div>;
   const current = getRoomById(run.roomGraph, run.currentRoomId);
@@ -109,11 +112,32 @@ export function DungeonScreen() {
           <span className="dungeon-header-biome muted small">{biome.description}</span>
         </div>
         <div className="dungeon-actions">
-          <Button variant="danger" onClick={() => {
-            if (confirm("Abandon the run? You will lose carried loot.")) abandon();
-          }}>Abandon Run</Button>
+          <Button variant="danger" onClick={() => setShowAbandonConfirm(true)}>Abandon Run</Button>
         </div>
       </header>
+
+      {showAbandonConfirm && (
+        <ConfirmDialog
+          title="Abandon the delve"
+          body="What you carry stays behind. The dungeon keeps what it is given."
+          confirmLabel="Leave it all"
+          cancelLabel="Stay"
+          danger
+          onConfirm={() => { setShowAbandonConfirm(false); abandon(); }}
+          onCancel={() => setShowAbandonConfirm(false)}
+        />
+      )}
+
+      {showDescendConfirm && (
+        <ConfirmDialog
+          title="Descend"
+          body="Unclaimed spoils on this floor will be lost to the dark below."
+          confirmLabel="Descend"
+          cancelLabel="Wait"
+          onConfirm={() => { setShowDescendConfirm(false); descend(); }}
+          onCancel={() => setShowDescendConfirm(false)}
+        />
+      )}
 
       <div className="dungeon-hud">
         <div className="dungeon-hud-hp">
@@ -179,7 +203,10 @@ export function DungeonScreen() {
             )}
             {current.type === "boss" && current.completed && (
               <Button variant="secondary" onClick={() => {
-                if (floorHasPendingLoot(run) && !confirm("Descend? Unclaimed loot on this floor will be lost.")) return;
+                if (floorHasPendingLoot(run)) {
+                  setShowDescendConfirm(true);
+                  return;
+                }
                 descend();
               }}>Descend</Button>
             )}

--- a/src/screens/MainMenuScreen.tsx
+++ b/src/screens/MainMenuScreen.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { Button } from "../components/Button";
+import { ConfirmDialog } from "../components/ConfirmDialog";
 import { useGameStore } from "../store/gameStore";
 import { hasSave } from "../game/save";
 
@@ -7,6 +9,7 @@ export function MainMenuScreen() {
   const continueGame = useGameStore(s => s.continueGame);
   const resetSave = useGameStore(s => s.resetSave);
   const hasExisting = hasSave();
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
 
   return (
     <div className="screen menu-screen">
@@ -16,12 +19,22 @@ export function MainMenuScreen() {
         <div className="menu-actions">
           <Button onClick={newGame}>New Game</Button>
           {hasExisting && <Button variant="secondary" onClick={continueGame}>Continue</Button>}
-          {hasExisting && <Button variant="danger" onClick={() => {
-            if (confirm("Delete your save and start fresh?")) resetSave();
-          }}>Reset Save</Button>}
+          {hasExisting && <Button variant="danger" onClick={() => setShowResetConfirm(true)}>Reset Save</Button>}
         </div>
         <p className="hint">Loot what you can. Get out alive. The village is waiting.</p>
       </div>
+
+      {showResetConfirm && (
+        <ConfirmDialog
+          title="Burn the chronicle"
+          body="Burn the chronicle and begin again. Your save will be gone for good."
+          confirmLabel="Burn it"
+          cancelLabel="Keep it"
+          danger
+          onConfirm={() => { setShowResetConfirm(false); resetSave(); }}
+          onCancel={() => setShowResetConfirm(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/screens/VillageScreen.tsx
+++ b/src/screens/VillageScreen.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { Button } from "../components/Button";
+import { ConfirmDialog } from "../components/ConfirmDialog";
 import { calculateInventoryWeight } from "../game/inventory";
 import { useGameStore } from "../store/gameStore";
 import { ServiceLevelBadge } from "../components/ServiceLevelBadge";
@@ -15,6 +17,7 @@ export function VillageScreen() {
   const toggleQuest = useGameStore(s => s.toggleQuestActive);
   const resetSave = useGameStore(s => s.resetSave);
   const message = useGameStore(s => s.lastVillageMessage);
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
 
   if (!player || !village) {
     return <div className="screen">Loading…</div>;
@@ -36,9 +39,21 @@ export function VillageScreen() {
               type="button"
               className="delve-hero-reset"
               title="Reset save and return to the title"
-              onClick={() => { if (confirm("Reset save and return to the title?")) resetSave(); }}
+              onClick={() => setShowResetConfirm(true)}
             >Reset</button>
           </div>
+
+          {showResetConfirm && (
+            <ConfirmDialog
+              title="Burn the chronicle"
+              body="Burn the chronicle and begin again. Nothing of this journey will remain."
+              confirmLabel="Burn it"
+              cancelLabel="Keep going"
+              danger
+              onConfirm={() => { setShowResetConfirm(false); resetSave(); }}
+              onCancel={() => setShowResetConfirm(false)}
+            />
+          )}
           <h1>Enter the Dungeon</h1>
           <div className="delve-hero-meta">
             <span><em>Pack</em> {preparedWeight} / {player.derivedStats.carryCapacity}</span>


### PR DESCRIPTION
Closes #14.

Four player-facing native confirms replaced with a diegetic dialog (dark panel, serif heading, Escape/Enter, focus trap, reduced-motion aware). Dev-panel confirm intentionally left native (dev tooling). Copy in the game voice: "What you carry stays behind. The dungeon keeps what it is given."

218/218 tests, typecheck clean. Co-located CSS; index.css untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)