### PR TITLE
Diegetic shell: nav as places, character plate instead of HP widget

### DIFF
--- a/src/components/GlobalNav.css
+++ b/src/components/GlobalNav.css
@@ -1,0 +1,157 @@
+/* GlobalNav — the "realm band": a strip of engraved stone/leather that
+   frames the game world rather than a SaaS app's tab bar. */
+
+.realm-band {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 9px 24px;
+  border-bottom: 1px solid var(--warm-line);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 40%),
+    radial-gradient(ellipse at 20% -40%, rgba(216, 178, 92, 0.08), transparent 60%),
+    rgba(13, 14, 18, 0.95);
+  backdrop-filter: blur(10px);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.35);
+}
+
+/* Places */
+.realm-band-places {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  min-width: 0;
+}
+
+.realm-place {
+  position: relative;
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 6px 12px 8px;
+  font-family: ui-serif, Georgia, serif;
+  font-size: 0.82rem;
+  font-variant: small-caps;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 120ms ease;
+}
+.realm-place:hover:not(:disabled) {
+  color: var(--text-dim);
+}
+.realm-place:disabled {
+  cursor: default;
+}
+.realm-place::after {
+  content: "";
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  height: 2px;
+  border-radius: 2px;
+  background: transparent;
+  transition: background 160ms ease, box-shadow 160ms ease;
+}
+.realm-place-active {
+  color: var(--accent-2);
+}
+.realm-place-active::after {
+  background: var(--accent);
+  box-shadow: 0 0 8px rgba(200, 155, 60, 0.55);
+}
+
+.realm-band-sep {
+  color: var(--warm-line);
+  font-size: 0.78rem;
+  padding: 0 2px;
+  user-select: none;
+}
+
+/* Character plate */
+.realm-plate {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  flex-shrink: 1;
+}
+.realm-plate-id {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  min-width: 0;
+}
+.realm-plate-name {
+  font-family: ui-serif, Georgia, serif;
+  font-size: 0.94rem;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 160px;
+}
+.realm-plate-meta {
+  font-variant: small-caps;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.realm-plate-meta-combat {
+  color: var(--danger);
+}
+
+.realm-hp {
+  position: relative;
+  width: 92px;
+  height: 9px;
+  border-radius: 5px;
+  background: var(--bg-3);
+  border: 1px solid var(--line);
+  overflow: hidden;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.55);
+  flex-shrink: 0;
+}
+.realm-hp-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: linear-gradient(180deg, #8fd68f, #5c9c5c);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  transition: width 240ms ease;
+}
+.realm-hp-mid .realm-hp-fill {
+  background: linear-gradient(180deg, var(--accent-2), var(--warn));
+}
+.realm-hp-low .realm-hp-fill {
+  background: linear-gradient(180deg, var(--warn), var(--danger));
+  animation: realm-hp-low-pulse 1.3s ease-in-out infinite;
+}
+@keyframes realm-hp-low-pulse {
+  0%, 100% { filter: brightness(1); }
+  50% { filter: brightness(1.18); }
+}
+
+@media (max-width: 900px) {
+  .realm-band {
+    padding: 8px 14px;
+    gap: 10px;
+  }
+  .realm-place {
+    padding: 6px 8px 8px;
+    font-size: 0.76rem;
+  }
+  .realm-plate-name {
+    max-width: 96px;
+  }
+  .realm-hp {
+    width: 64px;
+  }
+}

--- a/src/components/GlobalNav.tsx
+++ b/src/components/GlobalNav.tsx
@@ -1,6 +1,7 @@
-import { Button } from "./Button";
 import type { ScreenId } from "../game/types";
 import { useGameStore } from "../store/gameStore";
+import { playSfx } from "../game/audio";
+import "./GlobalNav.css";
 
 const SHELL_SCREENS = new Set<ScreenId>([
   "village",
@@ -29,43 +30,55 @@ export function GlobalNav() {
   const inRun = state.activeRun?.status === "active";
   const inCombat = Boolean(state.activeCombat);
 
+  const places: Array<{ id: ScreenId; label: string }> = [
+    { id: returnTarget, label: returnLabel },
+    { id: "character", label: "You" },
+    { id: "stash", label: "Pack" },
+    { id: "quests", label: "Chronicle" }
+  ];
+
+  const hpPct = player.maxHp > 0 ? Math.max(0, Math.min(100, (player.hp / player.maxHp) * 100)) : 0;
+  const hpTier = hpPct <= 25 ? "realm-hp-low" : hpPct <= 55 ? "realm-hp-mid" : "";
+
   return (
-    <nav className="global-nav" aria-label="Game navigation">
-      <div className="global-nav-main">
-        <Button
-          variant={screen === returnTarget ? "secondary" : "ghost"}
-          onClick={() => goToScreen(returnTarget)}
-          disabled={screen === returnTarget}
-        >
-          {returnLabel}
-        </Button>
-        <Button
-          variant={screen === "character" ? "secondary" : "ghost"}
-          onClick={() => goToScreen("character")}
-          disabled={screen === "character"}
-        >
-          Character
-        </Button>
-        <Button
-          variant={screen === "stash" ? "secondary" : "ghost"}
-          onClick={() => goToScreen("stash")}
-          disabled={screen === "stash"}
-        >
-          Inventory
-        </Button>
-        <Button
-          variant={screen === "quests" ? "secondary" : "ghost"}
-          onClick={() => goToScreen("quests")}
-          disabled={screen === "quests"}
-        >
-          Quests
-        </Button>
+    <nav className="realm-band" aria-label="Game navigation">
+      <div className="realm-band-places">
+        {places.map((place, index) => {
+          const active = screen === place.id;
+          return (
+            <span key={place.id} style={{ display: "flex", alignItems: "center" }}>
+              {index > 0 && <span className="realm-band-sep" aria-hidden="true">&middot;</span>}
+              <button
+                type="button"
+                className={`realm-place${active ? " realm-place-active" : ""}`}
+                onClick={() => {
+                  if (active) return;
+                  playSfx("button");
+                  goToScreen(place.id);
+                }}
+                disabled={active}
+                aria-current={active ? "page" : undefined}
+              >
+                {place.label}
+              </button>
+            </span>
+          );
+        })}
       </div>
-      <div className="global-nav-status">
-        <span>{player.name}</span>
-        <span>HP {player.hp}/{player.maxHp}</span>
-        {inCombat && <span>Combat</span>}
-        {!inCombat && inRun && <span>Depth {state.activeRun?.tier}</span>}
+      <div className="realm-plate">
+        <div
+          className={`realm-hp${hpTier ? ` ${hpTier}` : ""}`}
+          role="img"
+          aria-label={`HP ${player.hp} of ${player.maxHp}`}
+        >
+          <div className="realm-hp-fill" style={{ width: `${hpPct}%` }} />
+        </div>
+        <div className="realm-plate-id">
+          <span className="realm-plate-name">{player.name}</span>
+          <span className={`realm-plate-meta${inCombat ? " realm-plate-meta-combat" : ""}`}>
+            {inCombat ? "In Combat" : inRun ? `Depth ${state.activeRun?.tier}` : "At Rest"}
+          </span>
+        </div>
       </div>
     </nav>
   );
@@ -79,6 +92,6 @@ function getReturnTarget(state: ReturnType<typeof useGameStore.getState>["state"
 
 function getReturnLabel(screen: ScreenId): string {
   if (screen === "combat") return "Combat";
-  if (screen === "dungeon") return "Dungeon";
+  if (screen === "dungeon") return "The Delve";
   return "Village";
 }


### PR DESCRIPTION
Closes #16.

- Labels: Character -> You, Inventory -> Pack, Quests -> Chronicle; contextual Village/Delve/Combat tab logic unchanged
- Unstyled small-caps serif place names with dot separators; active place gets a warm underglow bar, no button chips
- Right side is a character plate: serif name, slim tiered HP bar, small-caps state (In Combat / Depth N / At Rest)
- Engraved-band treatment via gradients only; 900px tightening; all navigation behavior identical
- Co-located GlobalNav.css; index.css untouched

218/218 tests, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)