### PR TITLE
Prose-first village and character creation

### DIFF
--- a/src/components/VillageNpcDetail.css
+++ b/src/components/VillageNpcDetail.css
@@ -1,0 +1,10 @@
+.village-npc-detail-prose {
+  font-size: 1rem;
+  line-height: 1.55;
+  color: var(--text);
+  margin: 4px 0 10px;
+}
+.village-npc-detail-standing {
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}

--- a/src/components/VillageNpcDetail.tsx
+++ b/src/components/VillageNpcDetail.tsx
@@ -1,7 +1,7 @@
-import { ServiceLevelBadge } from "./ServiceLevelBadge";
 import { ServiceUpgradeCard } from "./ServiceUpgradeCard";
 import type { ServiceLevelDefinition, VillageNpc } from "../game/types";
 import { getRelationshipLabel } from "../game/villageProgression";
+import "./VillageNpcDetail.css";
 
 export function VillageNpcDetail({ npc, currentLevel, nextLevel, canUpgrade, reason, onUpgrade }: {
   npc: VillageNpc;
@@ -13,9 +13,10 @@ export function VillageNpcDetail({ npc, currentLevel, nextLevel, canUpgrade, rea
 }) {
   return (
     <div className="village-npc-detail">
-      <ServiceLevelBadge level={npc.service.level} label={currentLevel?.title} />
-      <p>{npc.description}</p>
-      <div className="muted small">Relationship: {getRelationshipLabel(npc.relationship)} ({npc.relationship}) · service XP {npc.service.xp}</div>
+      <p className="village-npc-detail-prose">{npc.description}</p>
+      <p className="village-npc-detail-standing muted small">
+        {getRelationshipLabel(npc.relationship)}{currentLevel ? ` · ${currentLevel.title}` : ""} · service standing {npc.service.xp}
+      </p>
       <ServiceUpgradeCard npc={npc} nextLevel={nextLevel} canUpgrade={canUpgrade} reason={reason} onUpgrade={onUpgrade} />
     </div>
   );

--- a/src/screens/CharacterCreationScreen.css
+++ b/src/screens/CharacterCreationScreen.css
@@ -1,0 +1,146 @@
+/* Character creation — the village taking you in, not a checkout wizard.
+   Same 70ch narrative column as the dungeon and village screens. */
+
+.creation-screen-prose { padding: 14px 24px 20px; display: flex; flex-direction: column; gap: 0; }
+
+.arrival-step-tag {
+  display: block;
+  font-size: 0.74rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.arrival-title {
+  font-size: 2rem;
+  margin: 0 0 10px;
+}
+
+.arrival-prose {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--text);
+  margin: 0 0 18px;
+}
+
+.answer-field { display: flex; flex-direction: column; gap: 6px; max-width: 420px; margin-bottom: 18px; }
+.answer-field-label {
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+}
+.answer-input {
+  background: transparent;
+  color: var(--text);
+  border: none;
+  border-bottom: 1px solid var(--line);
+  border-radius: 0;
+  padding: 8px 2px;
+  font-family: inherit;
+  font-size: 1.15rem;
+  font-style: italic;
+}
+.answer-input:focus { outline: none; border-bottom-color: var(--accent); }
+.answer-input::placeholder { color: var(--text-muted); font-style: italic; }
+
+.narrative-choice {
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 16px 18px;
+  margin-bottom: 16px;
+}
+.narrative-choice-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.narrative-choice-body { cursor: pointer; }
+.narrative-choice-label {
+  color: var(--text-dim);
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+}
+.narrative-choice-name {
+  margin: 0 0 4px;
+  font-size: 1.4rem;
+}
+.narrative-choice-trait { color: var(--text-dim); margin: 6px 0; }
+.narrative-choice-bonuses,
+.narrative-choice-stats {
+  margin: 8px 0 0;
+  padding-left: 1.2em;
+  color: var(--text-dim);
+  font-size: 0.9rem;
+}
+.narrative-choice-footer { margin-top: 12px; }
+
+.choice-list {
+  list-style: none;
+  margin: 0 0 16px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.choice-row {
+  display: block;
+  width: 100%;
+  padding: 12px 16px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font: inherit;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 100ms ease, background 100ms ease;
+}
+.choice-row:hover { border-color: var(--accent); background: var(--bg-2); }
+.choice-row-selected { border-color: var(--accent); background: rgba(200, 155, 60, 0.06); }
+.choice-row-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+.choice-row-name { color: var(--accent-2); font-weight: 600; }
+.choice-row-selected-tag {
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--good);
+}
+.choice-row-desc { margin: 4px 0 0; color: var(--text-dim); }
+.choice-row-items {
+  margin: 6px 0 0;
+  padding-left: 1.1em;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+.measure-block { margin-bottom: 18px; }
+.measure-scores { display: flex; gap: 8px; margin: 12px 0; }
+.measure-actions { display: flex; gap: 10px; flex-wrap: wrap; margin: 12px 0; }
+
+.chronicle-entry {
+  background: var(--bg-1);
+  border: 1px solid var(--warm-line);
+  border-radius: 8px;
+  padding: 18px 20px;
+  margin-bottom: 18px;
+}
+.chronicle-entry-name { font-size: 1.5rem; margin: 0 0 2px; }
+.chronicle-entry-sub { color: var(--text-muted); margin: 0 0 10px; }
+.chronicle-entry-stats { color: var(--text-dim); }
+.chronicle-entry-items {
+  margin: 10px 0 0;
+  padding-left: 1.2em;
+  color: var(--text-dim);
+  font-size: 0.9rem;
+}
+
+.arrival-actions { display: flex; gap: 10px; margin-top: 4px; margin-bottom: 24px; }

--- a/src/screens/CharacterCreationScreen.tsx
+++ b/src/screens/CharacterCreationScreen.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "../components/Button";
-import { Card } from "../components/Card";
 import { useGameStore } from "../store/gameStore";
 import { ANCESTRIES } from "../data/ancestries";
 import { CLASSES } from "../data/classes";
@@ -12,8 +11,17 @@ import { getClass } from "../data/classes";
 import { instanceFromTemplateId } from "../game/inventory";
 import { createRng } from "../game/rng";
 import type { AbilityName, EquipmentSlots, ItemInstance } from "../game/types";
+import "./CharacterCreationScreen.css";
 
 type Step = 0 | 1 | 2 | 3 | 4;
+
+const STEP_TAGS = [
+  "The Elder Asks",
+  "Your Calling",
+  "Taking Your Measure",
+  "Provisioning",
+  "The First Entry"
+];
 
 export function CharacterCreationScreen() {
   const draft = useGameStore(s => s.draft);
@@ -39,219 +47,241 @@ export function CharacterCreationScreen() {
 
   if (!draft) return null;
 
-  const stepLabels = ["Name & Ancestry", "Class", "Abilities", "Kit", "Confirm"];
-
   return (
-    <div className="screen creation-screen">
-      <div className="creation-header">
-        <h2>New Adventurer</h2>
-        <div className="step-indicator">
-          {stepLabels.map((s, i) => (
-            <span key={s} className={`step ${i === step ? "step-active" : i < step ? "step-done" : ""}`}>
-              {i + 1}. {s}
-            </span>
-          ))}
-        </div>
-      </div>
+    <div className="screen creation-screen creation-screen-prose">
+      <div className="narrative-scroll">
+        <div className="narrative-column">
+          <span className="arrival-step-tag">{step + 1} of {STEP_TAGS.length} · {STEP_TAGS[step]}</span>
 
-      {step === 0 && (
-        <div className="creation-step">
-          <label className="field">
-            <span>Name</span>
-            <input
-              className="text-input"
-              value={draft.name}
-              onChange={e => setName(e.target.value)}
-              placeholder="A name worth remembering"
-              maxLength={40}
-            />
-          </label>
+          {step === 0 && (
+            <div className="creation-step">
+              <h1 className="arrival-title">The Elder Asks</h1>
+              <p className="arrival-prose">
+                An old woman looks up from her ledger as you cross the threshold. She has seen
+                enough strangers arrive at this gate to know better than to ask twice. "Well," she
+                says. "Who are you, and what blood carries you?"
+              </p>
 
-          <Carousel
-            label="Ancestry"
-            index={ancestryIdx}
-            count={ANCESTRIES.length}
-            onPrev={() => setAncestryIdx((ancestryIdx - 1 + ANCESTRIES.length) % ANCESTRIES.length)}
-            onNext={() => setAncestryIdx((ancestryIdx + 1) % ANCESTRIES.length)}
-          >
-            {(() => {
-              const a = ANCESTRIES[ancestryIdx]!;
-              const isSelected = draft.ancestryId === a.id;
-              return (
-                <Card
-                  title={a.name}
-                  subtitle={isSelected ? "Selected" : ""}
-                  variant="warm"
-                  selectable
-                  selected={isSelected}
-                  onClick={() => selectAncestry(a.id)}
-                  footer={
-                    <Button
-                      variant={isSelected ? "secondary" : "primary"}
+              <label className="answer-field">
+                <span className="answer-field-label">Your Name</span>
+                <input
+                  className="answer-input"
+                  value={draft.name}
+                  onChange={e => setName(e.target.value)}
+                  placeholder="A name worth remembering"
+                  maxLength={40}
+                />
+              </label>
+
+              <NarrativeCarousel
+                label="Bloodline"
+                index={ancestryIdx}
+                count={ANCESTRIES.length}
+                onPrev={() => setAncestryIdx((ancestryIdx - 1 + ANCESTRIES.length) % ANCESTRIES.length)}
+                onNext={() => setAncestryIdx((ancestryIdx + 1) % ANCESTRIES.length)}
+              >
+                {(() => {
+                  const a = ANCESTRIES[ancestryIdx]!;
+                  const isSelected = draft.ancestryId === a.id;
+                  return (
+                    <div
+                      className={`narrative-choice-body${isSelected ? " narrative-choice-body-selected" : ""}`}
                       onClick={() => selectAncestry(a.id)}
                     >
-                      {isSelected ? "Selected" : "Choose"}
-                    </Button>
-                  }
-                >
-                  <p>{a.description}</p>
-                  <p><strong>{a.traitName}.</strong> {a.traitDescription}</p>
-                  <BonusList bonuses={a.bonuses} />
-                </Card>
-              );
-            })()}
-          </Carousel>
+                      <div className="narrative-choice-controls">
+                        <h2 className="narrative-choice-name">{a.name}</h2>
+                        {isSelected && <span className="choice-row-selected-tag">Chosen</span>}
+                      </div>
+                      <p>{a.description}</p>
+                      <p className="narrative-choice-trait"><strong>{a.traitName}.</strong> {a.traitDescription}</p>
+                      <BonusList bonuses={a.bonuses} />
+                      <div className="narrative-choice-footer">
+                        <Button
+                          variant={isSelected ? "secondary" : "primary"}
+                          onClick={() => selectAncestry(a.id)}
+                        >
+                          {isSelected ? "Chosen" : "Claim this bloodline"}
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                })()}
+              </NarrativeCarousel>
 
-          <div className="creation-actions">
-            <Button onClick={() => setStep(1)} disabled={!draft.name.trim() || !draft.ancestryId}>
-              Continue
-            </Button>
-          </div>
-        </div>
-      )}
+              <div className="arrival-actions">
+                <Button onClick={() => setStep(1)} disabled={!draft.name.trim() || !draft.ancestryId}>
+                  Continue
+                </Button>
+              </div>
+            </div>
+          )}
 
-      {step === 1 && (
-        <div className="creation-step">
-          <Carousel
-            label="Class"
-            index={classIdx}
-            count={CLASSES.length}
-            onPrev={() => setClassIdx((classIdx - 1 + CLASSES.length) % CLASSES.length)}
-            onNext={() => setClassIdx((classIdx + 1) % CLASSES.length)}
-          >
-            {(() => {
-              const c = CLASSES[classIdx]!;
-              const isSelected = draft.classId === c.id;
-              return (
-                <Card
-                  title={c.name}
-                  subtitle={isSelected ? "Selected" : ""}
-                  variant="warm"
-                  selectable
-                  selected={isSelected}
-                  onClick={() => selectClass(c.id)}
-                  footer={
-                    <Button
-                      variant={isSelected ? "secondary" : "primary"}
+          {step === 1 && (
+            <div className="creation-step">
+              <h1 className="arrival-title">Your Calling</h1>
+              <p className="arrival-prose">
+                "And what calling did you take up, before this?" the elder asks. "The village
+                cares less for what you were than what you can still do."
+              </p>
+
+              <NarrativeCarousel
+                label="Calling"
+                index={classIdx}
+                count={CLASSES.length}
+                onPrev={() => setClassIdx((classIdx - 1 + CLASSES.length) % CLASSES.length)}
+                onNext={() => setClassIdx((classIdx + 1) % CLASSES.length)}
+              >
+                {(() => {
+                  const c = CLASSES[classIdx]!;
+                  const isSelected = draft.classId === c.id;
+                  return (
+                    <div
+                      className={`narrative-choice-body${isSelected ? " narrative-choice-body-selected" : ""}`}
                       onClick={() => selectClass(c.id)}
                     >
-                      {isSelected ? "Selected" : "Choose"}
-                    </Button>
-                  }
-                >
-                  <p>{c.description}</p>
-                  <ul className="class-stats">
-                    <li>Base HP: {c.baseHp}</li>
-                    <li>Accuracy: +{c.baseAccuracy}</li>
-                    <li>Armor: +{c.baseArmor}</li>
-                    <li>Magic Bonus: +{c.magicBonus}</li>
-                    <li>Preferred: {c.preferredAbilities.join(", ")}</li>
-                  </ul>
-                </Card>
-              );
-            })()}
-          </Carousel>
-          <div className="creation-actions">
-            <Button variant="ghost" onClick={() => setStep(0)}>Back</Button>
-            <Button onClick={() => setStep(2)} disabled={!draft.classId}>Continue</Button>
-          </div>
+                      <div className="narrative-choice-controls">
+                        <h2 className="narrative-choice-name">{c.name}</h2>
+                        {isSelected && <span className="choice-row-selected-tag">Chosen</span>}
+                      </div>
+                      <p>{c.description}</p>
+                      <ul className="narrative-choice-stats">
+                        <li>Base HP: {c.baseHp}</li>
+                        <li>Accuracy: +{c.baseAccuracy}</li>
+                        <li>Armor: +{c.baseArmor}</li>
+                        <li>Magic Bonus: +{c.magicBonus}</li>
+                        <li>Preferred: {c.preferredAbilities.join(", ")}</li>
+                      </ul>
+                      <div className="narrative-choice-footer">
+                        <Button
+                          variant={isSelected ? "secondary" : "primary"}
+                          onClick={() => selectClass(c.id)}
+                        >
+                          {isSelected ? "Chosen" : "Take up this calling"}
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                })()}
+              </NarrativeCarousel>
+
+              <div className="arrival-actions">
+                <Button variant="ghost" onClick={() => setStep(0)}>Back</Button>
+                <Button onClick={() => setStep(2)} disabled={!draft.classId}>Continue</Button>
+              </div>
+            </div>
+          )}
+
+          {step === 2 && (
+            <div className="creation-step">
+              <h1 className="arrival-title">Taking Your Measure</h1>
+              <p className="arrival-prose">
+                The elder walks a slow circle around you, the way a buyer walks a circle around a
+                horse. 4d6, drop the lowest. You may reroll up to {CHARACTER_CREATION.abilityRolls.rerollLimit} times
+                before she stops humoring you.
+              </p>
+
+              <div className="measure-block">
+                <div className="measure-scores">
+                  {draft.rolledScores.length === 0
+                    ? <em>Taking your measure…</em>
+                    : draft.rolledScores.map((v, i) => (<span key={i} className="score-chip">{v}</span>))}
+                </div>
+                <div className="measure-actions">
+                  <Button variant="ghost" onClick={reroll}
+                    disabled={draft.rerollsUsed >= CHARACTER_CREATION.abilityRolls.rerollLimit}>
+                    Reroll All ({CHARACTER_CREATION.abilityRolls.rerollLimit - draft.rerollsUsed} left)
+                  </Button>
+                  <Button variant="secondary" onClick={autoAssign} disabled={!draft.classId || draft.rolledScores.length === 0}>
+                    Auto-Assign for Class
+                  </Button>
+                </div>
+
+                <ManualAssignTable />
+              </div>
+
+              <div className="arrival-actions">
+                <Button variant="ghost" onClick={() => setStep(1)}>Back</Button>
+                <Button onClick={() => setStep(3)} disabled={!draft.abilityScores}>Continue</Button>
+              </div>
+            </div>
+          )}
+
+          {step === 3 && draft.classId && (
+            <div className="creation-step">
+              <h1 className="arrival-title">Provisioning</h1>
+              <p className="arrival-prose">
+                The quartermaster lays a few kits across the counter, worn but serviceable.
+                "Pick what suits you," she says. "It won't be all you carry, but it's what you
+                start with."
+              </p>
+
+              <ul className="choice-list">
+                {getClass(draft.classId).starterKits.map(kit => {
+                  const selected = draft.starterKitId === kit.id;
+                  return (
+                    <li key={kit.id}>
+                      <button
+                        type="button"
+                        className={`choice-row${selected ? " choice-row-selected" : ""}`}
+                        onClick={() => selectKit(kit.id)}
+                      >
+                        <div className="choice-row-head">
+                          <span className="choice-row-name">{kit.name}</span>
+                          {selected && <span className="choice-row-selected-tag">Chosen</span>}
+                        </div>
+                        <p className="choice-row-desc">{kit.description}</p>
+                        <ul className="choice-row-items">
+                          {kit.itemTemplateIds.map(id => <li key={id}>{id.replace(/_/g, " ")}</li>)}
+                        </ul>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+
+              <div className="arrival-actions">
+                <Button variant="ghost" onClick={() => setStep(2)}>Back</Button>
+                <Button onClick={() => setStep(4)} disabled={!draft.starterKitId}>Continue</Button>
+              </div>
+            </div>
+          )}
+
+          {step === 4 && (
+            <div className="creation-step">
+              <h1 className="arrival-title">The First Entry</h1>
+              <p className="arrival-prose">
+                The elder closes her ledger on a fresh page and slides it across to you. This is
+                where your chronicle begins.
+              </p>
+              <ConfirmSummary />
+              <div className="arrival-actions">
+                <Button variant="ghost" onClick={() => setStep(3)}>Back</Button>
+                <Button onClick={() => finalize()} disabled={!CharacterCreationService.isReadyToFinalize(draft)}>
+                  Begin
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
-      )}
-
-      {step === 2 && (
-        <div className="creation-step">
-          <h3>Roll Abilities</h3>
-          <p>4d6, drop the lowest. You may reroll up to {CHARACTER_CREATION.abilityRolls.rerollLimit} times.</p>
-          <div className="rolled-scores">
-            {draft.rolledScores.length === 0
-              ? <em>Rolling…</em>
-              : draft.rolledScores.map((v, i) => (<span key={i} className="score-chip">{v}</span>))}
-          </div>
-          <div className="creation-actions">
-            <Button variant="ghost" onClick={reroll}
-              disabled={draft.rerollsUsed >= CHARACTER_CREATION.abilityRolls.rerollLimit}>
-              Reroll All ({CHARACTER_CREATION.abilityRolls.rerollLimit - draft.rerollsUsed} left)
-            </Button>
-            <Button variant="secondary" onClick={autoAssign} disabled={!draft.classId || draft.rolledScores.length === 0}>
-              Auto-Assign for Class
-            </Button>
-          </div>
-
-          <ManualAssignTable />
-
-          <div className="creation-actions">
-            <Button variant="ghost" onClick={() => setStep(1)}>Back</Button>
-            <Button onClick={() => setStep(3)} disabled={!draft.abilityScores}>Continue</Button>
-          </div>
-        </div>
-      )}
-
-      {step === 3 && draft.classId && (
-        <div className="creation-step">
-          <h3>Choose a Starting Kit</h3>
-          <div className="kit-grid">
-            {getClass(draft.classId).starterKits.map(kit => {
-              const selected = draft.starterKitId === kit.id;
-              return (
-                <Card
-                  key={kit.id}
-                  title={kit.name}
-                  subtitle={selected ? "Selected" : ""}
-                  variant="warm"
-                  selectable
-                  selected={selected}
-                  onClick={() => selectKit(kit.id)}
-                  footer={
-                    <Button variant={selected ? "secondary" : "primary"} onClick={() => selectKit(kit.id)}>
-                      {selected ? "Selected" : "Choose"}
-                    </Button>
-                  }
-                >
-                  <p>{kit.description}</p>
-                  <ul className="kit-list">
-                    {kit.itemTemplateIds.map(id => <li key={id}>{id.replace(/_/g, " ")}</li>)}
-                  </ul>
-                </Card>
-              );
-            })}
-          </div>
-          <div className="creation-actions">
-            <Button variant="ghost" onClick={() => setStep(2)}>Back</Button>
-            <Button onClick={() => setStep(4)} disabled={!draft.starterKitId}>Continue</Button>
-          </div>
-        </div>
-      )}
-
-      {step === 4 && (
-        <div className="creation-step">
-          <h3>Confirm</h3>
-          <ConfirmSummary />
-          <div className="creation-actions">
-            <Button variant="ghost" onClick={() => setStep(3)}>Back</Button>
-            <Button onClick={() => finalize()} disabled={!CharacterCreationService.isReadyToFinalize(draft)}>
-              Begin
-            </Button>
-          </div>
-        </div>
-      )}
+      </div>
     </div>
   );
 }
 
-function Carousel({
+function NarrativeCarousel({
   label, index, count, onPrev, onNext, children
 }: {
   label: string; index: number; count: number;
   onPrev: () => void; onNext: () => void; children: React.ReactNode;
 }) {
   return (
-    <div className="carousel">
-      <div className="carousel-controls">
+    <div className="narrative-choice">
+      <div className="narrative-choice-controls">
         <Button variant="ghost" onClick={onPrev}>‹ Prev</Button>
-        <span className="carousel-label">{label} {index + 1} / {count}</span>
+        <span className="narrative-choice-label">{label} {index + 1} / {count}</span>
         <Button variant="ghost" onClick={onNext}>Next ›</Button>
       </div>
-      <div className="carousel-body">{children}</div>
+      <div>{children}</div>
     </div>
   );
 }
@@ -260,7 +290,7 @@ function BonusList({ bonuses }: { bonuses: Record<string, number | undefined> | 
   const entries = Object.entries(bonuses as Record<string, number | undefined>).filter(([, v]) => v !== undefined && v !== 0);
   if (entries.length === 0) return null;
   return (
-    <ul className="bonus-list">
+    <ul className="narrative-choice-bonuses">
       {entries.map(([k, v]) => (<li key={k}>{k}: {(v as number) > 0 ? `+${v}` : v}</li>))}
     </ul>
   );
@@ -340,15 +370,18 @@ function ConfirmSummary() {
   }
   const ds = calculateDerivedStats(draft.abilityScores, ancestry, cls, equipped);
   return (
-    <div className="confirm-summary">
-      <Card title={draft.name || "Unnamed"} subtitle={`${ancestry.name} ${cls.name}`}>
-        <p><strong>Kit:</strong> {kit.name}</p>
-        <p><strong>HP:</strong> {ds.maxHp} · <strong>Armor:</strong> {ds.armor} · <strong>Acc:</strong> +{ds.accuracy} · <strong>Eva:</strong> {ds.evasion}</p>
-        <p><strong>Carry:</strong> {ds.carryCapacity} · <strong>Magic:</strong> {ds.magicPower} · <strong>Crit:</strong> {ds.critChance}%</p>
-        <ul className="equipment-list">
-          {items.map(i => <li key={i.instanceId}>{i.name}</li>)}
-        </ul>
-      </Card>
+    <div className="chronicle-entry">
+      <h2 className="chronicle-entry-name">{draft.name || "Unnamed"}</h2>
+      <p className="chronicle-entry-sub">{ancestry.name} {cls.name} · {kit.name}</p>
+      <p className="chronicle-entry-stats">
+        <strong>HP:</strong> {ds.maxHp} · <strong>Armor:</strong> {ds.armor} · <strong>Acc:</strong> +{ds.accuracy} · <strong>Eva:</strong> {ds.evasion}
+      </p>
+      <p className="chronicle-entry-stats">
+        <strong>Carry:</strong> {ds.carryCapacity} · <strong>Magic:</strong> {ds.magicPower} · <strong>Crit:</strong> {ds.critChance}%
+      </p>
+      <ul className="chronicle-entry-items">
+        {items.map(i => <li key={i.instanceId}>{i.name}</li>)}
+      </ul>
     </div>
   );
 }

--- a/src/screens/VillageScreen.css
+++ b/src/screens/VillageScreen.css
@@ -1,0 +1,143 @@
+/* Village screen — prose column, same reading surface as the dungeon screen.
+   The village is a place, not a dashboard: one narrative column, the day's
+   decision framed prominently, NPCs read as a roster of people, not tiles. */
+
+.village-screen-prose { padding: 14px 24px 20px; display: flex; flex-direction: column; gap: 0; }
+
+.village-hero-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 2px;
+}
+.village-hero-name {
+  font-size: 0.76rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+}
+.village-hero-reset {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--text-muted);
+  font: inherit;
+  letter-spacing: 0.14em;
+  cursor: pointer;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+}
+.village-hero-reset:hover { color: var(--text-dim); }
+
+.village-hero-prose {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--text);
+  margin: 4px 0 18px;
+}
+
+.village-decision {
+  border: 1px solid var(--warm-line);
+  border-radius: 10px;
+  padding: 16px 20px 18px;
+  margin-bottom: 20px;
+  background:
+    radial-gradient(circle at 85% 10%, rgba(216, 178, 92, 0.10), transparent 55%),
+    linear-gradient(135deg, rgba(216, 178, 92, 0.04), rgba(13, 14, 18, 0)),
+    var(--warm-bg);
+  box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.35);
+}
+.village-decision-title {
+  margin: 0 0 10px;
+  font-size: 1.7rem;
+}
+.village-decision-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+.village-decision-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 18px;
+  font-variant-numeric: tabular-nums;
+}
+.village-decision-meta em {
+  font-style: normal;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  margin-right: 4px;
+}
+
+.village-section { margin-top: 8px; margin-bottom: 20px; }
+.village-section-heading {
+  font-size: 0.9rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+  margin: 0 0 10px;
+}
+
+.roster-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.roster-line {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 14px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font: inherit;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 100ms ease, background 100ms ease;
+}
+.roster-line:hover { border-color: var(--accent); background: var(--bg-2); }
+.roster-sentence strong { color: var(--accent-2); font-weight: 600; }
+.roster-trust-tag {
+  flex: 0 0 auto;
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.notice-board {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.notice-item {
+  padding: 10px 14px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.notice-item-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.notice-item-title { color: var(--text); }
+.notice-empty { color: var(--text-muted); font-style: italic; }
+.notice-board-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}

--- a/src/screens/VillageScreen.tsx
+++ b/src/screens/VillageScreen.tsx
@@ -3,8 +3,27 @@ import { Button } from "../components/Button";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { calculateInventoryWeight } from "../game/inventory";
 import { useGameStore } from "../store/gameStore";
-import { ServiceLevelBadge } from "../components/ServiceLevelBadge";
-import { getCurrentServiceLevelDefinition, getRelationshipLabel } from "../game/villageProgression";
+import { getRelationshipLabel } from "../game/villageProgression";
+import type { NpcRole, Quest } from "../game/types";
+import "./VillageScreen.css";
+
+const ROLE_VERB_PHRASES: Record<NpcRole, string> = {
+  blacksmith: "works the forge",
+  alchemist: "keeps the still going behind a curtain of bitter herbs",
+  enchanter: "reads the marks on old metal",
+  quartermaster: "minds the stores",
+  cartographer: "sketches the dungeon's margins in pale ink",
+  elder: "speaks for what's left of the village",
+  healer: "binds wounds with quiet patience",
+  trader: "haggles by the gate"
+};
+
+const TRUST_TAGS: Record<string, string> = {
+  Stranger: "barely knows you",
+  Trusted: "has come to trust you",
+  Ally: "counts you as an ally",
+  Devoted: "would go to war for you"
+};
 
 export function VillageScreen() {
   const player = useGameStore(s => s.state.player);
@@ -27,17 +46,17 @@ export function VillageScreen() {
   const activeQuests = village.quests.filter(q => q.status === "active");
   const completedQuests = village.quests.filter(q => q.status === "completed");
   const preparedWeight = calculateInventoryWeight(preparedInventory);
-  const queuedQuest = activeQuests[0] ?? availableQuests[0];
+  const noticeQuests = [...activeQuests, ...availableQuests].slice(0, 3);
 
   return (
-    <div className="screen village-screen">
-      <section className="delve-hero">
-        <div className="delve-hero-body">
-          <div className="delve-hero-place">
-            <span className="delve-hero-place-name">{village.name}</span>
+    <div className="screen village-screen village-screen-prose">
+      <div className="narrative-scroll">
+        <div className="narrative-column">
+          <div className="village-hero-row">
+            <span className="village-hero-name">{village.name}</span>
             <button
               type="button"
-              className="delve-hero-reset"
+              className="village-hero-reset"
               title="Reset save and return to the title"
               onClick={() => setShowResetConfirm(true)}
             >Reset</button>
@@ -54,77 +73,87 @@ export function VillageScreen() {
               onCancel={() => setShowResetConfirm(false)}
             />
           )}
-          <h1>Enter the Dungeon</h1>
-          <div className="delve-hero-meta">
-            <span><em>Pack</em> {preparedWeight} / {player.derivedStats.carryCapacity}</span>
-            <span><em>Gold</em> {stash.gold}</span>
-            <span><em>Active quests</em> {activeQuests.length}</span>
-            <span><em>Renown</em> {village.renown}</span>
-          </div>
-        </div>
-        <div className="delve-hero-actions">
-          <Button className="btn-hero" onClick={() => startRun()}>Enter the Dungeon</Button>
-          <Button variant="secondary" onClick={() => goToScreen("stash")}>Pack Gear</Button>
-        </div>
-      </section>
 
-      {message && <p className="msg village-message">{message}</p>}
+          <p className="village-hero-prose">
+            The morning comes in cold, the kind that sits in the joints. Lanterns still burn
+            along the palisade, though the sky beyond the tree line has gone the grey of first
+            light. Somewhere below the frost line the dungeon waits; it has never once been in
+            a hurry.
+          </p>
 
-      <section className="village-courtyard">
-        <header className="village-courtyard-head">
-          <h2>Courtyard</h2>
-          <span className="muted small">{village.npcs.length} in town</span>
-        </header>
-        <ul className="npc-grid">
-          {village.npcs.map(npc => {
-            const currentLevel = getCurrentServiceLevelDefinition({ npc });
-            return (
-              <li key={npc.id} className="npc-tile" onClick={() => openMerchant(npc.id)}>
-                <div className="npc-tile-head">
-                  <strong>{npc.name}</strong>
-                  <span className="muted small">{capitalize(npc.role)}</span>
-                </div>
-                <div className="npc-tile-sub">
-                  <ServiceLevelBadge level={npc.service.level} label={currentLevel?.title} />
-                  <span className="muted small">Trust {getRelationshipLabel(npc.relationship)}</span>
-                </div>
-              </li>
-            );
-          })}
-        </ul>
-      </section>
+          {message && <p className="msg village-message">{message}</p>}
 
-      <section className="village-footer">
-        <div className="village-quest-strip">
-          <div className="village-quest-strip-main">
-            <span className="village-quest-eyebrow">Quest Board</span>
-            {queuedQuest ? (
-              <>
-                <strong>{queuedQuest.title}</strong>
-                <span className="muted small">
-                  {queuedQuest.status === "active"
-                    ? `Progress ${queuedQuest.currentCount}/${queuedQuest.requiredCount}`
-                    : "New posting"}
-                </span>
-              </>
-            ) : (
-              <span className="muted">No posted work.</span>
-            )}
-          </div>
-          <div className="village-quest-strip-actions">
-            {queuedQuest?.status === "available" && (
-              <Button variant="ghost" onClick={() => toggleQuest(queuedQuest.id)}>Accept</Button>
-            )}
-            <Button variant="secondary" onClick={() => goToScreen("quests")}>
-              Quest Log · {availableQuests.length} open · {completedQuests.length} ready
-            </Button>
-          </div>
+          <section className="village-decision" aria-label="Today's decision">
+            <h1 className="village-decision-title">Enter the Dungeon</h1>
+            <div className="village-decision-actions">
+              <Button className="btn-hero" onClick={() => startRun()}>Enter the Dungeon</Button>
+              <Button variant="secondary" onClick={() => goToScreen("stash")}>Pack Gear</Button>
+            </div>
+            <div className="village-decision-meta muted small">
+              <span><em>Pack</em> {preparedWeight} / {player.derivedStats.carryCapacity}</span>
+              <span><em>Gold</em> {stash.gold}</span>
+              <span><em>Active quests</em> {activeQuests.length}</span>
+              <span><em>Renown</em> {village.renown}</span>
+            </div>
+          </section>
+
+          <section className="village-section" aria-label="Villagers">
+            <h3 className="village-section-heading">In the Village</h3>
+            <ul className="roster-list">
+              {village.npcs.map(npc => {
+                const trustLabel = getRelationshipLabel(npc.relationship);
+                const trustTag = TRUST_TAGS[trustLabel] ?? trustLabel.toLowerCase();
+                const verb = ROLE_VERB_PHRASES[npc.role] ?? npc.description.toLowerCase();
+                return (
+                  <li key={npc.id}>
+                    <button
+                      type="button"
+                      className="roster-line"
+                      onClick={() => openMerchant(npc.id)}
+                    >
+                      <span className="roster-sentence">
+                        <strong>{npc.name}</strong> {verb}; {trustTag}.
+                      </span>
+                      <span className="roster-trust-tag">{trustLabel}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+
+          <section className="village-section" aria-label="Quest board">
+            <h3 className="village-section-heading">Posted Notices</h3>
+            <div className="notice-board">
+              {noticeQuests.length === 0 ? (
+                <p className="notice-empty">No postings on the board today.</p>
+              ) : (
+                noticeQuests.map(quest => (
+                  <div className="notice-item" key={quest.id}>
+                    <div className="notice-item-main">
+                      <strong className="notice-item-title">{quest.title}</strong>
+                      <span className="muted small">{describeQuestStatus(quest)}</span>
+                    </div>
+                    {quest.status === "available" && (
+                      <Button variant="ghost" onClick={() => toggleQuest(quest.id)}>Accept</Button>
+                    )}
+                  </div>
+                ))
+              )}
+              <div className="notice-board-footer">
+                <Button variant="secondary" onClick={() => goToScreen("quests")}>
+                  Quest Log · {availableQuests.length} open · {completedQuests.length} ready
+                </Button>
+              </div>
+            </div>
+          </section>
         </div>
-      </section>
+      </div>
     </div>
   );
 }
 
-function capitalize(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1);
+function describeQuestStatus(quest: Quest): string {
+  if (quest.status === "active") return `Progress ${quest.currentCount}/${quest.requiredCount}`;
+  return "New posting";
 }


### PR DESCRIPTION
Closes #18.

- VillageScreen: narrative column — scene-setting prose, Enter the Dungeon as the day's decision, NPCs as one-line prose roster with diegetic trust, quest board as posted notices (now up to 3 postings, superset of old single-quest view)
- CharacterCreationScreen: same 5 steps/state machine reframed as an arrival (The Elder Asks / Your Calling / Taking Your Measure / Provisioning / The First Entry); numbered wizard chips replaced with quiet step tag
- VillageNpcDetail: badges -> prose standing line; props unchanged
- Co-located CSS; index.css untouched

218/218 tests, typecheck clean. Will be rebased over merged dialogs/shell work before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)