### PR TITLE
Shell review follow-ups: HP tier threshold, dead CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist-ssr
 coverage
 *.tsbuildinfo
 .claude/settings.local.json
+.claude/worktrees/

--- a/src/components/GlobalNav.tsx
+++ b/src/components/GlobalNav.tsx
@@ -38,7 +38,7 @@ export function GlobalNav() {
   ];
 
   const hpPct = player.maxHp > 0 ? Math.max(0, Math.min(100, (player.hp / player.maxHp) * 100)) : 0;
-  const hpTier = hpPct <= 25 ? "realm-hp-low" : hpPct <= 55 ? "realm-hp-mid" : "";
+  const hpTier = hpPct <= 25 ? "realm-hp-low" : hpPct <= 50 ? "realm-hp-mid" : "";
 
   return (
     <nav className="realm-band" aria-label="Game navigation">

--- a/src/index.css
+++ b/src/index.css
@@ -81,31 +81,6 @@ body {
   background: transparent;
 }
 
-.global-nav {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 24px;
-  border-bottom: 1px solid var(--line);
-  background: rgba(13, 14, 18, 0.94);
-  backdrop-filter: blur(10px);
-}
-.global-nav-main,
-.global-nav-status {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-.global-nav-status {
-  color: var(--text-muted);
-  font-size: 0.88rem;
-}
-
 .screen {
   padding: 24px;
   max-width: 1200px;


### PR DESCRIPTION
Two one-liners flagged by the PR #20 review: amber HP tier at <=50 to match the other bars, and removal of the now-orphaned .global-nav rules from index.css.

🤖 Generated with [Claude Code](https://claude.com/claude-code)