### PR TITLE
Ambient audio: threat-responsive dungeon drone, village bed, combat ducking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import { CharacterScreen } from "./screens/CharacterScreen";
 import { QuestScreen } from "./screens/QuestScreen";
 import { GlobalNav, shouldShowGlobalNav } from "./components/GlobalNav";
 import { DevPanel } from "./components/DevPanel";
+import { AudioControl } from "./components/AudioControl";
+import { useAmbientAudio } from "./game/ambient";
 
 export default function App() {
   const screen = useGameStore(s => s.screen);
@@ -24,8 +26,11 @@ export default function App() {
     boot();
   }, [boot]);
 
+  useAmbientAudio();
+
   return (
     <div className="app-root">
+      <AudioControl />
       {shouldShowGlobalNav(screen, hasPlayer) && <GlobalNav />}
       {screen === "mainMenu" && <MainMenuScreen />}
       {screen === "onboarding" && <OnboardingScreen />}

--- a/src/components/AudioControl.css
+++ b/src/components/AudioControl.css
@@ -1,0 +1,26 @@
+.audio-control {
+  position: fixed;
+  right: 0.6rem;
+  bottom: 0.6rem;
+  z-index: 40;
+  background: rgba(20, 18, 24, 0.55);
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 0.3rem 0.55rem;
+  font-size: 0.85rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.55;
+  transition: opacity 0.15s ease, background 0.15s ease;
+}
+
+.audio-control:hover,
+.audio-control:focus-visible {
+  opacity: 1;
+  background: rgba(20, 18, 24, 0.8);
+}
+
+.audio-control[data-muted="true"] {
+  opacity: 0.4;
+}

--- a/src/components/AudioControl.tsx
+++ b/src/components/AudioControl.tsx
@@ -1,0 +1,21 @@
+import "./AudioControl.css";
+import { useGameStore } from "../store/gameStore";
+
+/** Small unobtrusive mute toggle for ambient audio + SFX, bottom-right. */
+export function AudioControl() {
+  const muted = useGameStore(s => s.state.settings.audioMuted);
+  const updateSettings = useGameStore(s => s.updateSettings);
+
+  return (
+    <button
+      type="button"
+      className="audio-control"
+      data-muted={muted}
+      aria-label={muted ? "Unmute audio" : "Mute audio"}
+      title={muted ? "Unmute audio" : "Mute audio"}
+      onClick={() => updateSettings({ audioMuted: !muted })}
+    >
+      {muted ? "\u{1F507}" : "\u{1F50A}"}
+    </button>
+  );
+}

--- a/src/components/DevPanel.tsx
+++ b/src/components/DevPanel.tsx
@@ -30,7 +30,7 @@ export function DevPanel() {
               checked={!state.settings.audioMuted}
               onChange={event => updateSettings({ audioMuted: !event.currentTarget.checked })}
             />
-            SFX
+            Audio
           </label>
           <Button
             variant="danger"

--- a/src/game/ambient.ts
+++ b/src/game/ambient.ts
@@ -1,0 +1,566 @@
+import { useEffect, useRef } from "react";
+import { getAudioContext, isAudioMuted } from "./audio";
+import { useGameStore } from "../store/gameStore";
+import type { ScreenId, ThreatLevel } from "./types";
+
+// ---------------------------------------------------------------------------
+// Pure threat -> sound mapping (unit tested in src/tests/ambient.test.ts)
+// ---------------------------------------------------------------------------
+
+export interface DungeonAmbientParams {
+  /** Loudness of the core drone bed, in dBFS. */
+  droneGainDb: number;
+  /** Lowpass cutoff (Hz) the slow LFO sweeps around. */
+  filterHz: number;
+  /** Loudness of the detuned semitone-down "dissonant" partial, in dBFS.
+   *  Number.NEGATIVE_INFINITY means silent (not yet faded in). */
+  dissonantGainDb: number;
+  /** Whether the slow irregular pulse (threat 5 only) should run. */
+  pulseActive: boolean;
+  /** Base rate (Hz) of the pulse LFO when active. */
+  pulseRateHz: number;
+}
+
+/** Ambient bed base level while in the village. Warm, barely-there. */
+export const VILLAGE_DRONE_GAIN_DB = -34;
+export const VILLAGE_NOISE_GAIN_DB = -30;
+
+/** How much the ambient bed ducks under combat SFX. */
+export const COMBAT_DUCK_DB = -4;
+
+/** Smooth transition times, in seconds. */
+export const BED_CROSSFADE_SECONDS = 2;
+export const DUCK_RAMP_SECONDS = 1;
+
+const ROOT_FREQUENCY = 58; // ~Bb1, low drone root
+const DETUNE_RATIO = 1.006; // slight beating for thickness
+const DISSONANT_SEMITONE_RATIO = 2 ** (-1 / 12); // a semitone below root
+
+export function dbToGain(db: number): number {
+  if (!Number.isFinite(db)) return 0;
+  return Math.pow(10, db / 20);
+}
+
+function clampThreatLevel(level: number): ThreatLevel {
+  const rounded = Math.round(level);
+  return Math.max(0, Math.min(5, Number.isFinite(rounded) ? rounded : 0)) as ThreatLevel;
+}
+
+/**
+ * Maps the current run's threat level (0-5) to dungeon ambient parameters.
+ * Higher threat: slightly louder drone, a brighter filter, a semitone-down
+ * dissonant partial fading in from threat 3, and a slow irregular pulse at
+ * threat 5. Pure and deterministic so the mapping itself is unit testable
+ * separately from the WebAudio graph.
+ */
+export function computeDungeonAmbientParams(threatLevel: number): DungeonAmbientParams {
+  const level = clampThreatLevel(threatLevel);
+  const droneGainDb = -30 + level * 2; // -30 .. -20 dB
+  const filterHz = 300 + level * 45; // 300 .. 525 Hz
+  const dissonantGainDb = level >= 3 ? -30 + (level - 2) * 8 : Number.NEGATIVE_INFINITY; // -22 / -14 / -6
+  const pulseActive = level >= 5;
+  const pulseRateHz = pulseActive ? 0.18 : 0;
+
+  return { droneGainDb, filterHz, dissonantGainDb, pulseActive, pulseRateHz };
+}
+
+export function dungeonRootFrequencies(): {
+  root: number;
+  detuned: number;
+  dissonant: number;
+} {
+  return {
+    root: ROOT_FREQUENCY,
+    detuned: ROOT_FREQUENCY * DETUNE_RATIO,
+    dissonant: ROOT_FREQUENCY * DISSONANT_SEMITONE_RATIO
+  };
+}
+
+// ---------------------------------------------------------------------------
+// WebAudio engine
+// ---------------------------------------------------------------------------
+
+type AmbientBed = "none" | "dungeon" | "village";
+
+interface DungeonBedNodes {
+  bedGain: GainNode;
+  filter: BiquadFilterNode;
+  filterLfo: OscillatorNode;
+  filterLfoDepth: GainNode;
+  oscRoot: OscillatorNode;
+  oscDetuned: OscillatorNode;
+  oscDissonant: OscillatorNode;
+  dissonantGain: GainNode;
+  pulseLfoA: OscillatorNode;
+  pulseLfoB: OscillatorNode;
+  pulseDepth: GainNode;
+  noiseSource: AudioBufferSourceNode;
+  noiseFilter: BiquadFilterNode;
+  noiseGain: GainNode;
+}
+
+interface VillageBedNodes {
+  bedGain: GainNode;
+  windSource: AudioBufferSourceNode;
+  windFilter: BiquadFilterNode;
+  windGain: GainNode;
+  bellTimer: ReturnType<typeof setTimeout> | undefined;
+}
+
+function createNoiseBuffer(ctx: AudioContext): AudioBuffer {
+  const seconds = 2;
+  const buffer = ctx.createBuffer(1, ctx.sampleRate * seconds, ctx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < data.length; i++) {
+    data[i] = Math.random() * 2 - 1;
+  }
+  return buffer;
+}
+
+function rampTo(param: AudioParam, value: number, ctx: AudioContext, seconds: number): void {
+  try {
+    param.cancelScheduledValues(ctx.currentTime);
+    param.setValueAtTime(param.value, ctx.currentTime);
+    param.linearRampToValueAtTime(value, ctx.currentTime + seconds);
+  } catch {
+    // Ignore automation errors from an already-closed context.
+  }
+}
+
+/**
+ * Owns the ambient WebAudio graph: a dungeon drone bed and a village wind
+ * bed, cross-faded smoothly on screen change, ducked during combat, and torn
+ * down cleanly whenever a bed is no longer needed. Never throws — audio
+ * should never interrupt gameplay.
+ */
+export class AmbientEngine {
+  private ctx: AudioContext | undefined;
+  private masterGain: GainNode | undefined;
+  private noiseBuffer: AudioBuffer | undefined;
+
+  private dungeonBed: DungeonBedNodes | undefined;
+  private villageBed: VillageBedNodes | undefined;
+  private dungeonTeardownTimer: ReturnType<typeof setTimeout> | undefined;
+  private villageTeardownTimer: ReturnType<typeof setTimeout> | undefined;
+
+  private currentBed: AmbientBed = "none";
+  private screen: ScreenId | "none" = "none";
+  private threatLevel: ThreatLevel = 0;
+  private ducking = false;
+  private muted = isAudioMuted();
+
+  /** Call from a first click/keydown handler to satisfy autoplay policy. */
+  resume(): void {
+    if (this.ctx) return;
+    const ctx = getAudioContext();
+    if (!ctx) return;
+    this.ctx = ctx;
+    this.masterGain = ctx.createGain();
+    this.masterGain.gain.value = 0;
+    this.masterGain.connect(ctx.destination);
+    this.applyBedForScreen();
+    this.applyMasterLevel();
+  }
+
+  setScreen(screen: ScreenId): void {
+    this.screen = screen;
+    this.ducking = screen === "combat";
+    this.applyBedForScreen();
+    this.applyMasterLevel();
+  }
+
+  setThreatLevel(level: ThreatLevel): void {
+    this.threatLevel = level;
+    this.applyThreatParams();
+  }
+
+  setMuted(muted: boolean): void {
+    this.muted = muted;
+    this.applyMasterLevel();
+  }
+
+  dispose(): void {
+    this.cancelDungeonTeardown();
+    this.cancelVillageTeardown();
+    this.teardownDungeonBed();
+    this.teardownVillageBed();
+    this.masterGain?.disconnect();
+    this.masterGain = undefined;
+    this.ctx = undefined;
+    this.currentBed = "none";
+  }
+
+  private desiredBed(): AmbientBed {
+    if (this.screen === "dungeon" || this.screen === "combat") return "dungeon";
+    if (this.screen === "village") return "village";
+    return "none";
+  }
+
+  private applyBedForScreen(): void {
+    if (!this.ctx || !this.masterGain) return;
+    const desired = this.desiredBed();
+    if (desired === this.currentBed) return;
+
+    const ctx = this.ctx;
+    const previousBed = this.currentBed;
+    this.currentBed = desired;
+
+    if (previousBed === "dungeon" && this.dungeonBed) {
+      rampTo(this.dungeonBed.bedGain.gain, 0, ctx, BED_CROSSFADE_SECONDS);
+      this.scheduleDungeonTeardown();
+    }
+    if (previousBed === "village" && this.villageBed) {
+      rampTo(this.villageBed.bedGain.gain, 0, ctx, BED_CROSSFADE_SECONDS);
+      this.scheduleVillageTeardown();
+    }
+
+    try {
+      if (desired === "dungeon") {
+        // Cancel a pending fade-out teardown if we're returning to this bed
+        // within the crossfade window (e.g. a quick village hub detour).
+        this.cancelDungeonTeardown();
+        if (!this.dungeonBed) this.dungeonBed = this.buildDungeonBed(ctx, this.masterGain);
+      }
+      if (desired === "village") {
+        this.cancelVillageTeardown();
+        if (!this.villageBed) this.villageBed = this.buildVillageBed(ctx, this.masterGain);
+      }
+    } catch {
+      // Never let a graph-build failure break gameplay.
+    }
+
+    this.applyThreatParams();
+    this.applyVillageLevel();
+  }
+
+  private scheduleDungeonTeardown(): void {
+    if (this.dungeonTeardownTimer) clearTimeout(this.dungeonTeardownTimer);
+    this.dungeonTeardownTimer = setTimeout(() => {
+      this.dungeonTeardownTimer = undefined;
+      this.teardownDungeonBed();
+    }, (BED_CROSSFADE_SECONDS + 0.2) * 1000);
+  }
+
+  private cancelDungeonTeardown(): void {
+    if (!this.dungeonTeardownTimer) return;
+    clearTimeout(this.dungeonTeardownTimer);
+    this.dungeonTeardownTimer = undefined;
+  }
+
+  private scheduleVillageTeardown(): void {
+    if (this.villageTeardownTimer) clearTimeout(this.villageTeardownTimer);
+    this.villageTeardownTimer = setTimeout(() => {
+      this.villageTeardownTimer = undefined;
+      this.teardownVillageBed();
+    }, (BED_CROSSFADE_SECONDS + 0.2) * 1000);
+  }
+
+  private cancelVillageTeardown(): void {
+    if (!this.villageTeardownTimer) return;
+    clearTimeout(this.villageTeardownTimer);
+    this.villageTeardownTimer = undefined;
+  }
+
+  /** Re-ramps the village bed to its active level; a no-op unless the
+   *  village bed is current (covers both fresh builds and revivals of a
+   *  bed that was mid fade-out). */
+  private applyVillageLevel(): void {
+    if (!this.ctx || !this.villageBed || this.currentBed !== "village") return;
+    rampTo(this.villageBed.bedGain.gain, dbToGain(VILLAGE_DRONE_GAIN_DB), this.ctx, BED_CROSSFADE_SECONDS);
+  }
+
+  private applyThreatParams(): void {
+    if (!this.ctx || !this.dungeonBed || this.currentBed !== "dungeon") return;
+    const ctx = this.ctx;
+    const bed = this.dungeonBed;
+    const params = computeDungeonAmbientParams(this.threatLevel);
+
+    rampTo(bed.bedGain.gain, dbToGain(params.droneGainDb), ctx, BED_CROSSFADE_SECONDS);
+    rampTo(bed.filter.frequency, params.filterHz, ctx, BED_CROSSFADE_SECONDS);
+    rampTo(bed.dissonantGain.gain, dbToGain(params.dissonantGainDb), ctx, BED_CROSSFADE_SECONDS);
+    rampTo(
+      bed.pulseDepth.gain,
+      params.pulseActive ? dbToGain(params.droneGainDb) * 0.25 : 0,
+      ctx,
+      BED_CROSSFADE_SECONDS
+    );
+  }
+
+  private applyMasterLevel(): void {
+    if (!this.ctx || !this.masterGain) return;
+    const target = this.muted ? 0 : this.ducking ? dbToGain(COMBAT_DUCK_DB) : 1;
+    rampTo(this.masterGain.gain, target, this.ctx, DUCK_RAMP_SECONDS);
+  }
+
+  private getNoiseBuffer(ctx: AudioContext): AudioBuffer {
+    this.noiseBuffer ??= createNoiseBuffer(ctx);
+    return this.noiseBuffer;
+  }
+
+  private buildDungeonBed(ctx: AudioContext, destination: AudioNode): DungeonBedNodes {
+    const bedGain = ctx.createGain();
+    bedGain.gain.value = 0;
+    bedGain.connect(destination);
+
+    const filter = ctx.createBiquadFilter();
+    filter.type = "lowpass";
+    filter.frequency.value = 300;
+    filter.Q.value = 0.6;
+    filter.connect(bedGain);
+
+    const filterLfo = ctx.createOscillator();
+    filterLfo.type = "sine";
+    filterLfo.frequency.value = 0.04;
+    const filterLfoDepth = ctx.createGain();
+    filterLfoDepth.gain.value = 60;
+    filterLfo.connect(filterLfoDepth);
+    filterLfoDepth.connect(filter.frequency);
+    filterLfo.start();
+
+    const freqs = dungeonRootFrequencies();
+
+    const oscRoot = ctx.createOscillator();
+    oscRoot.type = "sine";
+    oscRoot.frequency.value = freqs.root;
+    const oscRootGain = ctx.createGain();
+    oscRootGain.gain.value = 0.55;
+    oscRoot.connect(oscRootGain);
+    oscRootGain.connect(filter);
+    oscRoot.start();
+
+    const oscDetuned = ctx.createOscillator();
+    oscDetuned.type = "sine";
+    oscDetuned.frequency.value = freqs.detuned;
+    const oscDetunedGain = ctx.createGain();
+    oscDetunedGain.gain.value = 0.3;
+    oscDetuned.connect(oscDetunedGain);
+    oscDetunedGain.connect(filter);
+    oscDetuned.start();
+
+    const dissonantGain = ctx.createGain();
+    dissonantGain.gain.value = 0;
+    dissonantGain.connect(filter);
+    const oscDissonant = ctx.createOscillator();
+    oscDissonant.type = "sine";
+    oscDissonant.frequency.value = freqs.dissonant;
+    oscDissonant.connect(dissonantGain);
+    oscDissonant.start();
+
+    // Two slightly-offset slow LFOs summed together read as an irregular
+    // pulse rather than a clean metronomic one.
+    const pulseDepth = ctx.createGain();
+    pulseDepth.gain.value = 0;
+    pulseDepth.connect(bedGain.gain);
+    const pulseLfoA = ctx.createOscillator();
+    pulseLfoA.type = "sine";
+    pulseLfoA.frequency.value = 0.13;
+    pulseLfoA.connect(pulseDepth);
+    pulseLfoA.start();
+    const pulseLfoB = ctx.createOscillator();
+    pulseLfoB.type = "sine";
+    pulseLfoB.frequency.value = 0.19;
+    pulseLfoB.connect(pulseDepth);
+    pulseLfoB.start();
+
+    const noiseSource = ctx.createBufferSource();
+    noiseSource.buffer = this.getNoiseBuffer(ctx);
+    noiseSource.loop = true;
+    const noiseFilter = ctx.createBiquadFilter();
+    noiseFilter.type = "lowpass";
+    noiseFilter.frequency.value = 480;
+    const noiseGain = ctx.createGain();
+    noiseGain.gain.value = 0.04; // very quiet, "distant air" floor
+    noiseSource.connect(noiseFilter);
+    noiseFilter.connect(noiseGain);
+    noiseGain.connect(bedGain);
+    noiseSource.start();
+
+    return {
+      bedGain,
+      filter,
+      filterLfo,
+      filterLfoDepth,
+      oscRoot,
+      oscDetuned,
+      oscDissonant,
+      dissonantGain,
+      pulseLfoA,
+      pulseLfoB,
+      pulseDepth,
+      noiseSource,
+      noiseFilter,
+      noiseGain
+    };
+  }
+
+  private teardownDungeonBed(): void {
+    const bed = this.dungeonBed;
+    if (!bed) return;
+    this.dungeonBed = undefined;
+    for (const node of [bed.filterLfo, bed.oscRoot, bed.oscDetuned, bed.oscDissonant, bed.pulseLfoA, bed.pulseLfoB]) {
+      try {
+        node.stop();
+      } catch {
+        // already stopped
+      }
+    }
+    try {
+      bed.noiseSource.stop();
+    } catch {
+      // already stopped
+    }
+    for (const node of [
+      bed.bedGain,
+      bed.filter,
+      bed.filterLfo,
+      bed.filterLfoDepth,
+      bed.oscRoot,
+      bed.oscDetuned,
+      bed.oscDissonant,
+      bed.dissonantGain,
+      bed.pulseLfoA,
+      bed.pulseLfoB,
+      bed.pulseDepth,
+      bed.noiseSource,
+      bed.noiseFilter,
+      bed.noiseGain
+    ]) {
+      try {
+        node.disconnect();
+      } catch {
+        // already disconnected
+      }
+    }
+  }
+
+  private buildVillageBed(ctx: AudioContext, destination: AudioNode): VillageBedNodes {
+    const bedGain = ctx.createGain();
+    bedGain.gain.value = 0;
+    bedGain.connect(destination);
+
+    const windSource = ctx.createBufferSource();
+    windSource.buffer = this.getNoiseBuffer(ctx);
+    windSource.loop = true;
+    const windFilter = ctx.createBiquadFilter();
+    windFilter.type = "bandpass";
+    windFilter.frequency.value = 700;
+    windFilter.Q.value = 0.5;
+    const windGain = ctx.createGain();
+    windGain.gain.value = dbToGain(VILLAGE_NOISE_GAIN_DB);
+    windSource.connect(windFilter);
+    windFilter.connect(windGain);
+    windGain.connect(bedGain);
+    windSource.start();
+
+    const bed: VillageBedNodes = { bedGain, windSource, windFilter, windGain, bellTimer: undefined };
+    this.scheduleVillageBell(bed);
+    return bed;
+  }
+
+  private scheduleVillageBell(bed: VillageBedNodes): void {
+    const delayMs = (20 + Math.random() * 40) * 1000;
+    bed.bellTimer = setTimeout(() => {
+      if (this.villageBed !== bed || !this.ctx) return;
+      this.playVillageBell(bed);
+      this.scheduleVillageBell(bed);
+    }, delayMs);
+  }
+
+  private playVillageBell(bed: VillageBedNodes): void {
+    const ctx = this.ctx;
+    if (!ctx) return;
+    try {
+      const start = ctx.currentTime;
+      const decay = 3.5;
+      const baseFreq = 480 + Math.random() * 220;
+
+      for (const [ratio, level] of [
+        [1, 0.05],
+        [2.4, 0.02]
+      ] as const) {
+        const osc = ctx.createOscillator();
+        osc.type = "sine";
+        osc.frequency.value = baseFreq * ratio;
+        const gain = ctx.createGain();
+        gain.gain.setValueAtTime(0.0001, start);
+        gain.gain.exponentialRampToValueAtTime(level, start + 0.05);
+        gain.gain.exponentialRampToValueAtTime(0.0001, start + decay);
+        osc.connect(gain);
+        gain.connect(bed.bedGain);
+        osc.start(start);
+        osc.stop(start + decay + 0.1);
+      }
+    } catch {
+      // Skip this bell; the ambient bed keeps running.
+    }
+  }
+
+  private teardownVillageBed(): void {
+    const bed = this.villageBed;
+    if (!bed) return;
+    this.villageBed = undefined;
+    if (bed.bellTimer) clearTimeout(bed.bellTimer);
+    try {
+      bed.windSource.stop();
+    } catch {
+      // already stopped
+    }
+    for (const node of [bed.bedGain, bed.windSource, bed.windFilter, bed.windGain]) {
+      try {
+        node.disconnect();
+      } catch {
+        // already disconnected
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// React wiring
+// ---------------------------------------------------------------------------
+
+function isInCombat(screen: ScreenId, hasActiveCombat: boolean): boolean {
+  return screen === "combat" || hasActiveCombat;
+}
+
+/**
+ * Mounts the ambient engine for the lifetime of the app. Reads screen and
+ * threat state from the store, resumes the shared AudioContext on the first
+ * user gesture (autoplay policy), and tears everything down on unmount.
+ */
+export function useAmbientAudio(): void {
+  const engineRef = useRef<AmbientEngine>();
+  if (!engineRef.current) engineRef.current = new AmbientEngine();
+
+  const screen = useGameStore(s => s.screen);
+  const threatLevel = useGameStore(s => s.state.activeRun?.threat.level ?? 0);
+  const hasActiveCombat = useGameStore(s => Boolean(s.state.activeCombat && !s.state.activeCombat.over));
+  const muted = useGameStore(s => s.state.settings.audioMuted);
+
+  useEffect(() => {
+    const engine = engineRef.current;
+    if (!engine) return;
+
+    const resume = () => engine.resume();
+    window.addEventListener("click", resume, { once: true });
+    window.addEventListener("keydown", resume, { once: true });
+
+    return () => {
+      window.removeEventListener("click", resume);
+      window.removeEventListener("keydown", resume);
+      engine.dispose();
+    };
+  }, []);
+
+  useEffect(() => {
+    engineRef.current?.setScreen(isInCombat(screen, hasActiveCombat) ? "combat" : screen);
+  }, [screen, hasActiveCombat]);
+
+  useEffect(() => {
+    engineRef.current?.setThreatLevel(threatLevel as ThreatLevel);
+  }, [threatLevel]);
+
+  useEffect(() => {
+    engineRef.current?.setMuted(muted);
+  }, [muted]);
+}

--- a/src/game/audio.ts
+++ b/src/game/audio.ts
@@ -77,17 +77,35 @@ export function isAudioMuted(): boolean {
   return muted;
 }
 
-export function playSfx(id: SfxId): void {
-  if (muted || typeof window === "undefined") return;
+/**
+ * Lazily creates (and resumes) the single shared AudioContext used by both
+ * one-shot SFX and the ambient bed, so the two systems never fight over
+ * separate contexts. Returns undefined in unsupported/SSR environments so
+ * callers can no-op gracefully.
+ */
+export function getAudioContext(): AudioContext | undefined {
+  if (typeof window === "undefined") return undefined;
   const AudioContextCtor = window.AudioContext ?? window.webkitAudioContext;
-  if (!AudioContextCtor) return;
+  if (!AudioContextCtor) return undefined;
 
   try {
     audioContext ??= new AudioContextCtor();
     if (audioContext.state === "suspended") {
       void audioContext.resume();
     }
-    playPattern(audioContext, SFX_PATTERNS[id]);
+    return audioContext;
+  } catch {
+    return undefined;
+  }
+}
+
+export function playSfx(id: SfxId): void {
+  if (muted) return;
+  const ctx = getAudioContext();
+  if (!ctx) return;
+
+  try {
+    playPattern(ctx, SFX_PATTERNS[id]);
   } catch {
     // Audio should never interrupt gameplay if the browser refuses playback.
   }

--- a/src/tests/ambient.test.ts
+++ b/src/tests/ambient.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeDungeonAmbientParams,
+  dbToGain,
+  dungeonRootFrequencies,
+  COMBAT_DUCK_DB,
+  VILLAGE_DRONE_GAIN_DB
+} from "../game/ambient";
+
+describe("ambient threat mapping", () => {
+  it("is quiet, dark-filtered, and dissonance-free at threat 0", () => {
+    const params = computeDungeonAmbientParams(0);
+    expect(params.droneGainDb).toBe(-30);
+    expect(params.filterHz).toBe(300);
+    expect(params.dissonantGainDb).toBe(Number.NEGATIVE_INFINITY);
+    expect(params.pulseActive).toBe(false);
+  });
+
+  it("gets louder and brighter monotonically as threat rises", () => {
+    const levels = [0, 1, 2, 3, 4, 5].map(level => computeDungeonAmbientParams(level));
+    for (let i = 1; i < levels.length; i++) {
+      expect(levels[i].droneGainDb).toBeGreaterThan(levels[i - 1].droneGainDb);
+      expect(levels[i].filterHz).toBeGreaterThan(levels[i - 1].filterHz);
+    }
+  });
+
+  it("fades in the dissonant partial starting at threat 3", () => {
+    expect(computeDungeonAmbientParams(2).dissonantGainDb).toBe(Number.NEGATIVE_INFINITY);
+    expect(computeDungeonAmbientParams(3).dissonantGainDb).toBeGreaterThan(Number.NEGATIVE_INFINITY);
+    expect(computeDungeonAmbientParams(4).dissonantGainDb).toBeGreaterThan(
+      computeDungeonAmbientParams(3).dissonantGainDb
+    );
+    expect(computeDungeonAmbientParams(5).dissonantGainDb).toBeGreaterThan(
+      computeDungeonAmbientParams(4).dissonantGainDb
+    );
+  });
+
+  it("only enables the irregular pulse at threat 5", () => {
+    for (const level of [0, 1, 2, 3, 4]) {
+      expect(computeDungeonAmbientParams(level).pulseActive).toBe(false);
+      expect(computeDungeonAmbientParams(level).pulseRateHz).toBe(0);
+    }
+    const top = computeDungeonAmbientParams(5);
+    expect(top.pulseActive).toBe(true);
+    expect(top.pulseRateHz).toBeGreaterThan(0);
+  });
+
+  it("clamps out-of-range or non-finite threat levels", () => {
+    expect(computeDungeonAmbientParams(-3)).toEqual(computeDungeonAmbientParams(0));
+    expect(computeDungeonAmbientParams(99)).toEqual(computeDungeonAmbientParams(5));
+    expect(computeDungeonAmbientParams(Number.NaN)).toEqual(computeDungeonAmbientParams(0));
+  });
+
+  it("converts dB to a linear gain, with -Infinity as true silence", () => {
+    expect(dbToGain(0)).toBeCloseTo(1, 5);
+    expect(dbToGain(Number.NEGATIVE_INFINITY)).toBe(0);
+    expect(dbToGain(-6)).toBeGreaterThan(dbToGain(-12));
+  });
+
+  it("keeps the dissonant partial a semitone below the drone root", () => {
+    const freqs = dungeonRootFrequencies();
+    const semitoneRatio = freqs.dissonant / freqs.root;
+    expect(semitoneRatio).toBeCloseTo(2 ** (-1 / 12), 5);
+    expect(freqs.detuned).toBeGreaterThan(freqs.root);
+  });
+
+  it("keeps combat duck and village bed constants in a tasteful quiet range", () => {
+    expect(COMBAT_DUCK_DB).toBeLessThan(0);
+    expect(VILLAGE_DRONE_GAIN_DB).toBeLessThan(-20);
+  });
+});

--- a/src/tests/ambientEngine.test.ts
+++ b/src/tests/ambientEngine.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { AmbientEngine, VILLAGE_DRONE_GAIN_DB, dbToGain } from "../game/ambient";
+
+// Minimal stub graph so the WebAudio node-lifecycle logic in AmbientEngine
+// (bed builds, crossfades, scheduled teardowns) can run headlessly in jsdom,
+// which has no real AudioContext. Automation methods snap straight to the
+// target value instead of simulating time-based ramps — that's fine here
+// since these tests only assert on final state, not ramp shape (which is
+// covered informally by the pure computeDungeonAmbientParams mapping tests).
+function makeParam(initial = 0) {
+  return {
+    value: initial,
+    setValueAtTime(v: number) {
+      this.value = v;
+    },
+    linearRampToValueAtTime(v: number) {
+      this.value = v;
+    },
+    exponentialRampToValueAtTime(v: number) {
+      this.value = v;
+    },
+    cancelScheduledValues() {
+      // no-op for the stub
+    }
+  };
+}
+
+function makeNode(extra: Record<string, unknown> = {}) {
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    ...extra
+  };
+}
+
+class MockAudioContext {
+  currentTime = 0;
+  sampleRate = 44100;
+  state: AudioContextState = "running";
+  destination = makeNode();
+  resume = vi.fn(async () => {
+    this.state = "running";
+  });
+
+  createGain() {
+    return makeNode({ gain: makeParam(0) });
+  }
+
+  createOscillator() {
+    return makeNode({ type: "sine", frequency: makeParam(0), start: vi.fn(), stop: vi.fn() });
+  }
+
+  createBiquadFilter() {
+    return makeNode({ type: "lowpass", frequency: makeParam(0), Q: makeParam(0) });
+  }
+
+  createBufferSource() {
+    return makeNode({ buffer: null, loop: false, start: vi.fn(), stop: vi.fn() });
+  }
+
+  createBuffer(_channels: number, length: number) {
+    return { getChannelData: () => new Float32Array(length) };
+  }
+}
+
+interface EngineInternals {
+  villageBed?: { bedGain: { gain: { value: number } } };
+  dungeonBed?: { bedGain: { gain: { value: number } } };
+}
+
+describe("AmbientEngine bed revival", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (window as unknown as { AudioContext: typeof AudioContext }).AudioContext =
+      MockAudioContext as unknown as typeof AudioContext;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps the village bed alive and re-ramped when returning within the crossfade window", () => {
+    const engine = new AmbientEngine();
+    engine.resume();
+    engine.setScreen("village");
+
+    expect((engine as unknown as EngineInternals).villageBed).toBeDefined();
+
+    // Leave village (teardown scheduled ~2.2s out) then come back before it fires.
+    engine.setScreen("merchant");
+    vi.advanceTimersByTime(800);
+    engine.setScreen("village");
+
+    // Advance well past when the stale teardown would have fired.
+    vi.advanceTimersByTime(3000);
+
+    const villageBed = (engine as unknown as EngineInternals).villageBed;
+    expect(villageBed).toBeDefined();
+    expect(villageBed?.bedGain.gain.value).toBeCloseTo(dbToGain(VILLAGE_DRONE_GAIN_DB), 5);
+
+    engine.dispose();
+  });
+
+  it("keeps the dungeon bed alive when a menu detour is shorter than the crossfade window", () => {
+    const engine = new AmbientEngine();
+    engine.resume();
+    engine.setScreen("dungeon");
+
+    expect((engine as unknown as EngineInternals).dungeonBed).toBeDefined();
+
+    engine.setScreen("character");
+    vi.advanceTimersByTime(500);
+    engine.setScreen("dungeon");
+    vi.advanceTimersByTime(3000);
+
+    expect((engine as unknown as EngineInternals).dungeonBed).toBeDefined();
+
+    engine.dispose();
+  });
+
+  it("actually tears the bed down once the crossfade window fully elapses without revival", () => {
+    const engine = new AmbientEngine();
+    engine.resume();
+    engine.setScreen("village");
+    expect((engine as unknown as EngineInternals).villageBed).toBeDefined();
+
+    engine.setScreen("merchant");
+    vi.advanceTimersByTime(3000);
+
+    expect((engine as unknown as EngineInternals).villageBed).toBeUndefined();
+
+    engine.dispose();
+  });
+});


### PR DESCRIPTION
Closes #17.

- AmbientEngine (WebAudio synth, no assets): dungeon drone whose gain/filter/dissonance scale with threat 0-5 (pulse at L5), village wind + randomized distant bell; 2s crossfades between beds, -4dB duck in combat
- Autoplay-safe: context only touched after first click/keydown by construction
- Mute: small fixed speaker control unified with the existing persisted settings.audioMuted flag (DevPanel toggle relabeled)
- Pure threat->params mapping unit-tested; headless engine tests with a stub AudioContext (caught a real stale-teardown bug during development)

229/229 tests, typecheck + production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)