### PR TITLE
Pacing layer: staggered combat text, room fade-ins, threat pulse

### DIFF
--- a/src/components/DungeonLog.tsx
+++ b/src/components/DungeonLog.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { DungeonLogEntry } from "../game/types";
+import { useStaggeredReveal } from "./useStaggeredReveal";
+import "./dungeonLogPacing.css";
+
+const DUNGEON_LOG_REVEAL_INTERVAL_MS = 120;
 
 export interface DungeonLogProps {
   entries: DungeonLogEntry[];
@@ -57,7 +61,9 @@ export function DungeonLog({ entries, limit = 50 }: DungeonLogProps) {
   const listRef = useRef<HTMLUListElement | null>(null);
   const tail = entries.slice(Math.max(0, entries.length - limit));
   const displayEntries = useMemo(() => collapseEntries(tail), [tail]);
-  const latestId = displayEntries[displayEntries.length - 1]?.id;
+  const { revealed } = useStaggeredReveal(displayEntries.length, DUNGEON_LOG_REVEAL_INTERVAL_MS);
+  const visibleEntries = displayEntries.slice(0, revealed);
+  const latestId = visibleEntries[visibleEntries.length - 1]?.id;
 
   useEffect(() => {
     const el = listRef.current;
@@ -65,17 +71,17 @@ export function DungeonLog({ entries, limit = 50 }: DungeonLogProps) {
     el.scrollTop = el.scrollHeight;
   }, [latestId]);
 
-  if (displayEntries.length === 0) {
+  if (visibleEntries.length === 0) {
     return <p className="muted small dungeon-log-empty">The dungeon is still.</p>;
   }
 
   // Older entries fade out the further they are from the latest. The 6 most
   // recent each get progressively dimmer; anything older settles at the
   // dimmest tier.
-  const total = displayEntries.length;
+  const total = visibleEntries.length;
   return (
     <ul ref={listRef} className="dungeon-log dungeon-log-diegetic" aria-label="Recent dungeon events">
-      {displayEntries.map((entry, idx) => {
+      {visibleEntries.map((entry, idx) => {
         const fromLatest = total - 1 - idx;
         const recencyClass = fromLatest === 0
           ? "dungeon-log-now"
@@ -85,7 +91,7 @@ export function DungeonLog({ entries, limit = 50 }: DungeonLogProps) {
         return (
           <li
             key={entry.id}
-            className={`dungeon-log-entry dungeon-log-${entry.type} ${recencyClass}`}
+            className={`dungeon-log-entry dungeon-log-${entry.type} ${recencyClass} dungeon-log-entry-in`}
           >
             {entry.message}
           </li>

--- a/src/components/dungeonLogPacing.css
+++ b/src/components/dungeonLogPacing.css
@@ -1,0 +1,26 @@
+/*
+ * Display-only pacing for DungeonLog (issue #15): entries new since the last
+ * render fade in staggered; older entries are untouched.
+ */
+.dungeon-log-entry.dungeon-log-entry-in {
+  animation: dungeon-log-entry-in 300ms ease-out backwards;
+}
+
+@keyframes dungeon-log-entry-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dungeon-log-entry.dungeon-log-entry-in {
+    animation: none !important;
+    transform: none !important;
+    opacity: 1 !important;
+  }
+}

--- a/src/components/useStaggeredReveal.ts
+++ b/src/components/useStaggeredReveal.ts
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Display-only pacing helpers. None of these touch store/game state — they
+ * only decide how quickly already-computed state gets *shown*.
+ */
+
+/** Tracks the OS/browser "prefers-reduced-motion" setting reactively. */
+export function usePrefersReducedMotion(): boolean {
+  const getMatch = () =>
+    typeof window !== "undefined" && typeof window.matchMedia === "function"
+      ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      : false;
+
+  const [reduced, setReduced] = useState(getMatch);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handler = () => setReduced(mq.matches);
+    // Safari < 14 only supports addListener/removeListener.
+    if (mq.addEventListener) mq.addEventListener("change", handler);
+    else mq.addListener(handler);
+    return () => {
+      if (mq.removeEventListener) mq.removeEventListener("change", handler);
+      else mq.removeListener(handler);
+    };
+  }, []);
+
+  return reduced;
+}
+
+/**
+ * Reveals items 0..total one at a time, `intervalMs` apart, whenever `total`
+ * grows. Existing items already on screen are never re-animated: only the
+ * newly appended tail is staggered in. Respects prefers-reduced-motion by
+ * jumping straight to `total`. Call `skip()` to reveal everything immediately
+ * (e.g. on user click).
+ */
+export function useStaggeredReveal(total: number, intervalMs = 250) {
+  const reducedMotion = usePrefersReducedMotion();
+  const [revealed, setRevealed] = useState(total);
+  const revealedRef = useRef(total);
+
+  useEffect(() => {
+    // If the underlying collection shrank (e.g. a fresh combat log), never
+    // let the ref exceed the new total.
+    if (revealedRef.current > total) {
+      revealedRef.current = total;
+      setRevealed(total);
+    }
+
+    if (reducedMotion || revealedRef.current >= total) {
+      revealedRef.current = total;
+      setRevealed(total);
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      revealedRef.current = Math.min(total, revealedRef.current + 1);
+      setRevealed(revealedRef.current);
+      if (revealedRef.current >= total) {
+        window.clearInterval(timer);
+      }
+    }, intervalMs);
+
+    return () => window.clearInterval(timer);
+  }, [total, intervalMs, reducedMotion]);
+
+  const skip = () => {
+    revealedRef.current = total;
+    setRevealed(total);
+  };
+
+  return { revealed, isRevealing: revealed < total, skip };
+}
+
+/** Classic usePrevious: the value this hook held on the previous render. */
+export function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}
+
+/**
+ * Returns true for `durationMs` whenever `level` increases versus its
+ * previous value. Used to pulse a meter without the meter component itself
+ * knowing anything about pacing.
+ */
+export function useLevelIncreasePulse(level: number, durationMs = 600): boolean {
+  const reducedMotion = usePrefersReducedMotion();
+  const previous = usePrevious(level);
+  const [pulsing, setPulsing] = useState(false);
+
+  useEffect(() => {
+    if (reducedMotion) return;
+    if (previous !== undefined && level > previous) {
+      setPulsing(true);
+      const t = window.setTimeout(() => setPulsing(false), durationMs);
+      return () => window.clearTimeout(t);
+    }
+  }, [level, previous, durationMs, reducedMotion]);
+
+  return pulsing;
+}

--- a/src/screens/CombatScreen.tsx
+++ b/src/screens/CombatScreen.tsx
@@ -6,6 +6,10 @@ import { useGameStore } from "../store/gameStore";
 import type { EnemyInstance } from "../game/types";
 import { canUseCombatAction, getAvailableCombatActions } from "../game/combatActions";
 import type { ActiveCombatActionView } from "../components/v04UiTypes";
+import { useLevelIncreasePulse, useStaggeredReveal } from "../components/useStaggeredReveal";
+import "./pacing.css";
+
+const COMBAT_LOG_REVEAL_INTERVAL_MS = 250;
 
 type Fx =
   | { id: string; kind: "enemy-hit"; targetId: string; amount: number }
@@ -28,6 +32,9 @@ export function CombatScreen() {
   const [targetId, setTargetId] = useState<string | null>(null);
   const logRef = useRef<HTMLUListElement | null>(null);
   const logLength = combat?.log.length ?? 0;
+  const { revealed: revealedLogCount, isRevealing: logRevealPending, skip: skipLogReveal } =
+    useStaggeredReveal(logLength, COMBAT_LOG_REVEAL_INTERVAL_MS);
+  const threatPulsing = useLevelIncreasePulse(run?.threat.level ?? 0);
 
   const [fx, setFx] = useState<Fx[]>([]);
   const lastHp = useRef<{ player: number | null; enemies: Record<string, number> }>({
@@ -47,7 +54,7 @@ export function CombatScreen() {
     const el = logRef.current;
     if (!el) return;
     el.scrollTop = el.scrollHeight;
-  }, [logLength]);
+  }, [revealedLogCount]);
 
   useEffect(() => {
     if (!combat || !player) return;
@@ -129,7 +136,13 @@ export function CombatScreen() {
   const enemyHitsBy = (id: string) =>
     fx.filter((f): f is Extract<Fx, { kind: "enemy-hit" }> => f.kind === "enemy-hit" && f.targetId === id);
   const lowHp = player.hp / player.maxHp <= 0.25;
-  const classActions = getUnlockedClassActions(player, combat, Boolean(selectedTarget));
+  const classActions = getUnlockedClassActions(player, combat, Boolean(selectedTarget), logRevealPending);
+
+  const totalLogLines = combat.log.length;
+  const visibleLogCount = Math.min(revealedLogCount, totalLogLines);
+  const logWindowStart = Math.max(0, visibleLogCount - 50);
+  const displayLog = combat.log.slice(logWindowStart, visibleLogCount);
+  const combatOverRevealed = combat.over && !logRevealPending;
 
   return (
     <>
@@ -144,10 +157,14 @@ export function CombatScreen() {
             <h2>Turn {combat.turn}</h2>
           </div>
           <div className="combat-header-state">
-            {run && !combat.over && <ThreatMeter threat={run.threat} />}
-            {combat.over && combat.outcome === "victory" && <span className="good">Victory</span>}
-            {combat.over && combat.outcome === "fled" && <span className="warn">Withdrew</span>}
-            {combat.over && combat.outcome === "defeat" && <span className="danger">Defeated</span>}
+            {run && !combat.over && (
+              <div className={`threat-meter-pulse-wrap ${threatPulsing ? "threat-pulse" : ""}`}>
+                <ThreatMeter threat={run.threat} />
+              </div>
+            )}
+            {combatOverRevealed && combat.outcome === "victory" && <span className="good">Victory</span>}
+            {combatOverRevealed && combat.outcome === "fled" && <span className="warn">Withdrew</span>}
+            {combatOverRevealed && combat.outcome === "defeat" && <span className="danger">Defeated</span>}
           </div>
         </header>
 
@@ -193,9 +210,16 @@ export function CombatScreen() {
           </div>
         </section>
 
-        <section className="combat-log-panel" aria-live="polite">
+        <section
+          className="combat-log-panel"
+          aria-live="polite"
+          onClick={() => logRevealPending && skipLogReveal()}
+          title={logRevealPending ? "Click to skip ahead" : undefined}
+        >
           <ul className="combat-log" ref={logRef}>
-            {combat.log.slice(-50).map((line, i) => <li key={i}>{line}</li>)}
+            {displayLog.map((line, i) => (
+              <li key={logWindowStart + i} className="combat-log-line-in">{line}</li>
+            ))}
           </ul>
         </section>
 
@@ -209,29 +233,29 @@ export function CombatScreen() {
               />
               <Button
                 className="btn-hero combat-action-primary"
-                disabled={!selectedTarget}
+                disabled={!selectedTarget || logRevealPending}
                 onClick={() => selectedTarget && performAction({ kind: "attack", targetId: selectedTarget.instanceId })}
               >
                 Attack{selectedTarget ? ` · ${selectedTarget.name}` : ""}
               </Button>
               <Button
                 variant="secondary"
-                disabled={!selectedTarget}
+                disabled={!selectedTarget || logRevealPending}
                 onClick={() => selectedTarget && performAction({ kind: "powerAttack", targetId: selectedTarget.instanceId })}
               >Power Strike</Button>
-              <Button variant="secondary" onClick={() => performAction({ kind: "defend" })}>Defend</Button>
-              <Button variant="ghost" onClick={performAutoCombat}>Auto</Button>
+              <Button variant="secondary" disabled={logRevealPending} onClick={() => performAction({ kind: "defend" })}>Defend</Button>
+              <Button variant="ghost" disabled={logRevealPending} onClick={performAutoCombat}>Auto</Button>
               <Button variant="ghost" onClick={() => setShowItems(s => !s)}>{showItems ? "Hide Items" : "Items"}</Button>
-              <Button variant="danger" onClick={() => performAction({ kind: "flee" })}>Flee</Button>
+              <Button variant="danger" disabled={logRevealPending} onClick={() => performAction({ kind: "flee" })}>Flee</Button>
             </>
           )}
-          {combat.over && combat.outcome === "victory" && (
+          {combatOverRevealed && combat.outcome === "victory" && (
             <Button className="btn-hero" onClick={closeVictory}>Continue</Button>
           )}
-          {combat.over && combat.outcome === "fled" && (
+          {combatOverRevealed && combat.outcome === "fled" && (
             <Button onClick={closeFlee}>Withdraw</Button>
           )}
-          {combat.over && combat.outcome === "defeat" && (
+          {combatOverRevealed && combat.outcome === "defeat" && (
             <p className="muted">The dungeon takes its dues.</p>
           )}
         </footer>
@@ -266,7 +290,8 @@ export function CombatScreen() {
 function getUnlockedClassActions(
   player: NonNullable<ReturnType<typeof useGameStore.getState>["state"]["player"]>,
   combat: NonNullable<ReturnType<typeof useGameStore.getState>["state"]["activeCombat"]>,
-  hasTarget: boolean
+  hasTarget: boolean,
+  pendingReveal: boolean
 ): ActiveCombatActionView[] {
   return getAvailableCombatActions({ character: player, combatState: combat })
     .filter(action => Boolean(action.requiredTalentId))
@@ -276,8 +301,10 @@ function getUnlockedClassActions(
       const useCheck = canUseCombatAction({ character: player, combatState: combat, actionId: action.id });
       return {
         ...action,
-        disabled: !useCheck.canUse || (needsTarget && !hasTarget),
-        disabledReason: needsTarget && !hasTarget ? "Choose a living target." : useCheck.reason,
+        disabled: !useCheck.canUse || (needsTarget && !hasTarget) || pendingReveal,
+        disabledReason: pendingReveal
+          ? "Let the log catch up."
+          : needsTarget && !hasTarget ? "Choose a living target." : useCheck.reason,
         remainingCooldown: runtime?.remainingCooldown,
         usedThisCombat: runtime?.usedThisCombat
       };

--- a/src/screens/DungeonScreen.tsx
+++ b/src/screens/DungeonScreen.tsx
@@ -20,6 +20,8 @@ import type { ItemWithV4Fields } from "../components/v04UiTypes";
 import { getTrapTemplate } from "../data/trapTables";
 import { getEventTemplate } from "../data/eventTemplates";
 import { describeSign } from "../data/roomSigns";
+import { useLevelIncreasePulse } from "../components/useStaggeredReveal";
+import "./pacing.css";
 
 const TYPE_LABELS: Record<string, string> = {
   entrance: "Entrance",
@@ -71,6 +73,7 @@ export function DungeonScreen() {
   const [showLog, setShowLog] = useState(false);
   const [showAbandonConfirm, setShowAbandonConfirm] = useState(false);
   const [showDescendConfirm, setShowDescendConfirm] = useState(false);
+  const threatPulsing = useLevelIncreasePulse(run?.threat.level ?? 0);
 
   if (!run || !player) return <div className="screen">No active run.</div>;
   const current = getRoomById(run.roomGraph, run.currentRoomId);
@@ -150,7 +153,9 @@ export function DungeonScreen() {
             <span className="hp-bar-label">{player.hp} / {player.maxHp}</span>
           </div>
         </div>
-        <ThreatMeter threat={run.threat} />
+        <div className={`threat-meter-pulse-wrap ${threatPulsing ? "threat-pulse" : ""}`}>
+          <ThreatMeter threat={run.threat} />
+        </div>
         <span className="dungeon-hud-chip"><em>Pack</em> {raidWeight}/{carryCapacity}</span>
         <span className="dungeon-hud-chip"><em>Gold</em> {run.raidInventory.gold}</span>
         <span className="dungeon-hud-chip"><em>Value</em> {packValue}</span>
@@ -159,7 +164,10 @@ export function DungeonScreen() {
 
       <div className="narrative-scroll">
         <div className="narrative-column">
-          <div className={`room-hero ${current.dangerRating > 2 ? "room-hero-danger" : ""}`}>
+          <div
+            key={current.id}
+            className={`room-hero room-hero-enter ${current.dangerRating > 2 ? "room-hero-danger" : ""}`}
+          >
             <span className="room-hero-meta">
               {TYPE_LABELS[current.type] ?? current.type} · Danger {current.dangerRating} · {exitCount}/4 exits
             </span>
@@ -245,7 +253,7 @@ export function DungeonScreen() {
             />
           )}
 
-          <section className="passages-block" aria-label="Passages">
+          <section key={current.id} className="passages-block passages-enter" aria-label="Passages">
             <h3 className="passages-heading">Passages</h3>
             {passageRooms.length === 0 ? (
               <p className="muted small">No passages lead onward from here.</p>

--- a/src/screens/pacing.css
+++ b/src/screens/pacing.css
@@ -1,0 +1,86 @@
+/*
+ * Display-only pacing layer (issue #15). Nothing here touches store state —
+ * it only staggers/animates how already-computed state appears on screen.
+ */
+
+/* --- Combat log: each newly revealed line fades + rises in --- */
+.combat-log li.combat-log-line-in {
+  animation: combat-log-line-in 260ms ease-out backwards;
+}
+
+@keyframes combat-log-line-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* --- Room transitions: hero fades in, passages follow a beat later --- */
+.room-hero.room-hero-enter {
+  animation: room-hero-fade-in 300ms ease-out backwards;
+}
+
+@keyframes room-hero-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.passages-block.passages-enter {
+  animation: passages-fade-in 300ms ease-out 150ms backwards;
+}
+
+@keyframes passages-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* --- Threat pulse: fires when ThreatMeter's level increases --- */
+.threat-meter-pulse-wrap {
+  display: inline-flex;
+}
+
+.threat-meter-pulse-wrap.threat-pulse {
+  animation: threat-pulse 600ms ease-out;
+}
+
+@keyframes threat-pulse {
+  0% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 0 rgba(230, 134, 60, 0));
+  }
+  35% {
+    transform: scale(1.08);
+    filter: drop-shadow(0 0 6px rgba(230, 134, 60, 0.65));
+  }
+  100% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 0 rgba(230, 134, 60, 0));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .combat-log li.combat-log-line-in,
+  .room-hero.room-hero-enter,
+  .passages-block.passages-enter,
+  .threat-meter-pulse-wrap.threat-pulse {
+    animation: none !important;
+    transform: none !important;
+    opacity: 1 !important;
+  }
+}


### PR DESCRIPTION
Closes #15.

- Combat log lines reveal sequentially (250ms beats), actions disabled while pending, click-log-to-skip, Victory/Continue gated to final line
- Room hero fades in on room change (300ms), Passages follow 150ms later
- Dungeon log staggers new entries (120ms); threat meter pulses on level increase (600ms)
- Display-only: no store or game-logic changes; prefers-reduced-motion collapses everything to instant (JS + CSS)
- Rebased over dialogs/shell/audio/village; ConfirmDialog handlers adopted from main

229/229 tests, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)