### PR TITLE
Pack screen as the packing ritual

### DIFF
--- a/src/components/ItemComparePanel.css
+++ b/src/components/ItemComparePanel.css
@@ -1,0 +1,41 @@
+/* Item compare panel — the preview a player weighs before committing to a swap. */
+
+.compare-panel {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+  background: var(--bg-1);
+}
+.compare-panel-empty { color: var(--text-muted); }
+.compare-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+}
+.compare-panel-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--accent-2);
+  letter-spacing: 0.02em;
+}
+.compare-items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+  margin-top: 8px;
+}
+.compare-diff {
+  display: grid;
+  gap: 4px;
+  margin: 10px 0 0;
+}
+.compare-diff div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+.compare-diff dt { color: var(--text-muted); }
+.compare-diff dd { margin: 0; }

--- a/src/components/ItemComparePanel.tsx
+++ b/src/components/ItemComparePanel.tsx
@@ -1,6 +1,7 @@
 import { ItemTooltip } from "./ItemTooltip";
 import { ItemStateWarning } from "./ItemStateWarning";
 import type { EquipmentChangePreview } from "./v04UiTypes";
+import "./ItemComparePanel.css";
 
 export interface ItemComparePanelProps {
   preview?: EquipmentChangePreview;
@@ -9,7 +10,7 @@ export interface ItemComparePanelProps {
 export function ItemComparePanel({ preview }: ItemComparePanelProps) {
   if (!preview) {
     return (
-      <aside className="item-compare-panel item-compare-empty">
+      <aside className="compare-panel compare-panel-empty">
         <span className="muted">Select equipment to preview changes.</span>
       </aside>
     );
@@ -18,12 +19,12 @@ export function ItemComparePanel({ preview }: ItemComparePanelProps) {
   const diffs = Object.entries(preview.statDiff).filter(([, value]) => typeof value === "number" && value !== 0);
 
   return (
-    <aside className="item-compare-panel">
-      <header>
+    <aside className="compare-panel">
+      <header className="compare-panel-header">
         <span className="muted small">Preview</span>
         <h3>Equip {preview.newItem?.name ?? "Item"}?</h3>
       </header>
-      <div className="item-compare-items">
+      <div className="compare-items">
         <div>
           <span className="muted small">Current</span>
           {preview.currentItem ? <ItemTooltip item={preview.currentItem} /> : <em>Empty slot</em>}
@@ -34,7 +35,7 @@ export function ItemComparePanel({ preview }: ItemComparePanelProps) {
         </div>
       </div>
       {diffs.length > 0 ? (
-        <dl className="item-compare-diff">
+        <dl className="compare-diff">
           {diffs.map(([key, value]) => (
             <div key={key}>
               <dt>{formatStatLabel(key)}</dt>

--- a/src/components/LoadoutBuilder.css
+++ b/src/components/LoadoutBuilder.css
@@ -1,0 +1,76 @@
+/* Loadout builder — what you wear, as compact rows rather than a slot grid. */
+
+.loadout-slot-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.loadout-slot-row {
+  display: grid;
+  grid-template-columns: 6.5em 1fr auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  transition: border-color 100ms ease;
+}
+.loadout-slot-row-previewing { border-color: var(--accent); }
+.loadout-slot-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+}
+.loadout-slot-item {
+  color: var(--text);
+  border-bottom: 1px dotted var(--text-muted);
+  cursor: default;
+  width: fit-content;
+}
+.loadout-slot-empty { color: var(--text-muted); font-style: italic; }
+.loadout-slot-stat {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.loadout-pool { margin-top: 14px; }
+.loadout-pool-heading {
+  color: var(--text-dim);
+  font-size: 0.86rem;
+  letter-spacing: 0.04em;
+  margin: 0 0 6px;
+}
+.loadout-pool-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.loadout-pool-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+.loadout-pool-name {
+  color: var(--text);
+  border-bottom: 1px dotted var(--text-muted);
+  cursor: default;
+  width: fit-content;
+}
+.loadout-pool-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}

--- a/src/components/LoadoutBuilder.tsx
+++ b/src/components/LoadoutBuilder.tsx
@@ -1,8 +1,9 @@
 import { Button } from "./Button";
 import { ItemTooltip } from "./ItemTooltip";
-import { GearRiskBadge } from "./GearRiskBadge";
-import type { Character, EquipmentSlots, ItemInstance } from "../game/types";
-import type { EquipmentChangePreview, EquipmentSlotName, ItemWithV4Fields } from "./v04UiTypes";
+import { Tooltip } from "./Tooltip";
+import type { Character, EquipmentSlots, ItemInstance, StatModifierBlock } from "../game/types";
+import type { EquipmentChangePreview, EquipmentSlotName } from "./v04UiTypes";
+import "./LoadoutBuilder.css";
 
 export interface LoadoutBuilderProps {
   character: Character;
@@ -36,42 +37,48 @@ export function LoadoutBuilder({
   const equippable = inventoryItems.filter(canEquip);
   return (
     <section className="loadout-builder">
-      <div className="equipment-grid">
+      <ul className="loadout-slot-list">
         {(Object.keys(EQUIPMENT_LABELS) as EquipmentSlotName[]).map(slot => {
           const item = character.equipped[slot];
           return (
-            <div className={`equipment-slot ${preview?.slot === slot ? "equipment-slot-previewing" : ""}`} key={slot}>
-              <div className="equipment-slot-header">
-                <strong>{EQUIPMENT_LABELS[slot]}</strong>
-                {item && !readOnly && onUnequip && (
-                  <Button variant="ghost" onClick={() => onUnequip(slot)}>
-                    {activeRun ? "Pack" : "Unequip"}
-                  </Button>
-                )}
-                {!item && readOnly && <span className="muted small">Empty</span>}
-              </div>
+            <li
+              className={`loadout-slot-row ${preview?.slot === slot ? "loadout-slot-row-previewing" : ""}`}
+              key={slot}
+            >
+              <span className="loadout-slot-label">{EQUIPMENT_LABELS[slot]}</span>
               {item ? (
-                <>
-                  <ItemTooltip item={item} />
-                  <GearRiskBadge states={(item as ItemWithV4Fields).states} />
-                </>
+                <Tooltip content={<ItemTooltip item={item} />} as="span">
+                  <span className="loadout-slot-item">{item.name}</span>
+                </Tooltip>
               ) : (
-                <em className="muted">Empty</em>
+                <em className="loadout-slot-empty">Empty</em>
               )}
-            </div>
+              <span className="loadout-slot-stat muted small">
+                {item ? keyStatFor(item) : ""}
+              </span>
+              {item && !readOnly && onUnequip ? (
+                <Button variant="ghost" onClick={() => onUnequip(slot)}>
+                  {activeRun ? "Pack" : "Unequip"}
+                </Button>
+              ) : (
+                <span />
+              )}
+            </li>
           );
         })}
-      </div>
+      </ul>
 
       {equippable.length > 0 && !readOnly && (
         <div className="loadout-pool">
-          <h4>Available Gear</h4>
-          <div className="loadout-pool-grid">
+          <h4 className="loadout-pool-heading">Gear on hand</h4>
+          <ul className="loadout-pool-list">
             {equippable.map(item => {
               const slot = defaultSlotForItem(item, character.equipped);
               return (
-                <article key={item.instanceId} className="loadout-pool-item">
-                  <ItemTooltip item={item} comparisonItem={slot ? character.equipped[slot] : undefined} />
+                <li key={item.instanceId} className="loadout-pool-row">
+                  <Tooltip content={<ItemTooltip item={item} comparisonItem={slot ? character.equipped[slot] : undefined} />} as="span">
+                    <span className="loadout-pool-name">{item.name}</span>
+                  </Tooltip>
                   <div className="loadout-pool-actions">
                     {slot ? (
                       <>
@@ -82,10 +89,10 @@ export function LoadoutBuilder({
                       <span className="muted small">No valid slot</span>
                     )}
                   </div>
-                </article>
+                </li>
               );
             })}
-          </div>
+          </ul>
         </div>
       )}
     </section>
@@ -114,4 +121,34 @@ function defaultSlotForItem(item: ItemInstance, equipped: EquipmentSlots): Equip
     if (!equipped.trinket2) return "trinket2";
   }
   return valid[0];
+}
+
+const KEY_STAT_LABELS: Record<string, string> = {
+  might: "Might",
+  agility: "Agility",
+  endurance: "Endurance",
+  intellect: "Intellect",
+  will: "Will",
+  presence: "Presence",
+  maxHp: "Max HP",
+  armor: "Armor",
+  accuracy: "Accuracy",
+  evasion: "Evasion",
+  critChance: "Crit %",
+  carryCapacity: "Carry",
+  magicPower: "Magic",
+  trapSense: "Trap Sense"
+};
+
+function keyStatFor(item: ItemInstance): string {
+  const stats = item.stats;
+  if (!stats) return "";
+  const entries = Object.entries(stats).filter(
+    ([, value]) => typeof value === "number" && value !== 0
+  ) as Array<[keyof StatModifierBlock, number]>;
+  if (entries.length === 0) return "";
+  const [key, value] = entries[0];
+  const label = KEY_STAT_LABELS[key] ?? key;
+  const signed = value > 0 ? `+${value}` : String(value);
+  return `${signed} ${label}`;
 }

--- a/src/components/RunPreparationPanel.css
+++ b/src/components/RunPreparationPanel.css
@@ -1,0 +1,23 @@
+/* Before You Go — run preparations, keepsake, and insurance as solemn,
+   full-width choice rows (same grammar as the village notice board). */
+
+.vow-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.vow-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  flex-wrap: wrap;
+}
+.vow-row-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.vow-row-name { color: var(--text); }
+.vow-row-detail { color: var(--text-muted); font-size: 0.85em; }
+.pack-empty { color: var(--text-muted); font-style: italic; margin: 4px 0; }

--- a/src/components/RunPreparationPanel.tsx
+++ b/src/components/RunPreparationPanel.tsx
@@ -2,6 +2,7 @@ import { Button } from "./Button";
 import { formatResourceCost } from "../game/materials";
 import type { ItemInstance, PreparedRunModifier, RunPreparationOption, VillageNpc } from "../game/types";
 import { RUN_PREPARATION_RULES } from "../game/constants";
+import "./RunPreparationPanel.css";
 
 export interface RunPreparationPanelProps {
   options: RunPreparationOption[];
@@ -13,17 +14,19 @@ export interface RunPreparationPanelProps {
 export function RunPreparationPanel({ options, selectedPreparations, npcs = [], onPurchase }: RunPreparationPanelProps) {
   const selectedIds = new Set(selectedPreparations.map(prep => prep.optionId));
   return (
-    <div className="run-preparation-panel">
-      <div className="muted small">{selectedPreparations.length}/{RUN_PREPARATION_RULES.maxPreparedModifiers} preparations selected</div>
-      {options.length === 0 ? <div className="inv-empty">No run preparations unlocked.</div> : options.map(option => {
+    <div className="vow-list">
+      <p className="muted small">
+        {selectedPreparations.length}/{RUN_PREPARATION_RULES.maxPreparedModifiers} preparations selected
+      </p>
+      {options.length === 0 ? <div className="pack-empty">No run preparations unlocked.</div> : options.map(option => {
         const npc = npcs.find(entry => entry.role === option.sourceRole);
         const selected = selectedIds.has(option.id);
         return (
-          <div className="prep-card" key={option.id}>
-            <div>
-              <strong>{option.name}</strong>
-              <p>{option.description}</p>
-              <div className="muted small">{option.sourceRole} level {option.requiredServiceLevel} · {formatResourceCost(option.cost)}</div>
+          <div className="vow-row" key={option.id}>
+            <div className="vow-row-main">
+              <strong className="vow-row-name">{option.name}</strong>
+              <span className="vow-row-detail">{option.description}</span>
+              <span className="vow-row-detail">{option.sourceRole} level {option.requiredServiceLevel} · {formatResourceCost(option.cost)}</span>
             </div>
             <Button variant="ghost" disabled={selected || !npc} onClick={() => npc && onPurchase(option.id, npc.id)}>
               {selected ? "Prepared" : "Prepare"}
@@ -44,17 +47,16 @@ export interface KeepsakePanelProps {
 
 export function KeepsakePanel({ candidates, selectedInstanceId, onSelect, onClear }: KeepsakePanelProps) {
   return (
-    <div className="run-preparation-panel">
-      <p className="muted small">One weightless packed item can be designated a keepsake. It survives even if you die below.</p>
+    <div className="vow-list">
       {candidates.length === 0 ? (
-        <div className="inv-empty">Nothing weightless is packed.</div>
+        <div className="pack-empty">Nothing weightless is packed.</div>
       ) : candidates.map(item => {
         const selected = selectedInstanceId === item.instanceId;
         return (
-          <div className="prep-card" key={item.instanceId}>
-            <div>
-              <strong>{item.name}</strong>
-              <p>{item.description}</p>
+          <div className="vow-row" key={item.instanceId}>
+            <div className="vow-row-main">
+              <strong className="vow-row-name">{item.name}</strong>
+              <span className="vow-row-detail">{item.description}</span>
             </div>
             <Button
               variant="ghost"
@@ -80,19 +82,18 @@ export interface InsurancePanelProps {
 
 export function InsurancePanel({ candidates, selectedInstanceId, getCost, gold, onInsure, onCancel }: InsurancePanelProps) {
   return (
-    <div className="run-preparation-panel">
-      <p className="muted small">Insure one equipped piece of gear. If you die, it returns to the stash instead of being lost.</p>
+    <div className="vow-list">
       {candidates.length === 0 ? (
-        <div className="inv-empty">Nothing is equipped.</div>
+        <div className="pack-empty">Nothing is equipped.</div>
       ) : candidates.map(item => {
         const selected = selectedInstanceId === item.instanceId;
         const cost = getCost(item);
         const affordable = gold >= cost;
         return (
-          <div className="prep-card" key={item.instanceId}>
-            <div>
-              <strong>{item.name}</strong>
-              <div className="muted small">{cost}g to insure</div>
+          <div className="vow-row" key={item.instanceId}>
+            <div className="vow-row-main">
+              <strong className="vow-row-name">{item.name}</strong>
+              <span className="vow-row-detail">{cost}g to insure</span>
             </div>
             <Button
               variant="ghost"

--- a/src/screens/StashScreen.css
+++ b/src/screens/StashScreen.css
@@ -1,0 +1,135 @@
+/* Stash screen — the packing ritual (issue #28). One narrative column, same
+   reading surface as the village and dungeon screens. Packing is staged as
+   a sequence of decisions (wear, carry, leave, prepare), not a dashboard
+   of cards. */
+
+.pack-screen { padding: 14px 24px 20px; display: flex; flex-direction: column; gap: 0; }
+
+.pack-hero-eyebrow {
+  display: block;
+  font-size: 0.76rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+  margin-bottom: 2px;
+}
+
+.pack-hero-scene {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--text);
+  margin: 4px 0 14px;
+}
+
+.pack-status-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 18px;
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 18px;
+}
+.pack-status-line em {
+  font-style: normal;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  margin-right: 4px;
+}
+
+.pack-section { margin-top: 8px; margin-bottom: 22px; }
+.pack-section-heading {
+  font-size: 0.9rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+  margin: 0 0 4px;
+}
+.pack-section-intro {
+  color: var(--text-dim);
+  font-style: italic;
+  margin: 0 0 10px;
+}
+
+/* Weight budget — slim, felt near the cap. */
+.pack-weight-bar {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--bg-3);
+  overflow: hidden;
+  margin: 6px 0 12px;
+}
+.pack-weight-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  transition: width 150ms ease, background 150ms ease;
+}
+.pack-weight-bar-fill.pack-weight-amber { background: var(--warn); }
+.pack-weight-bar-fill.pack-weight-over { background: var(--danger); }
+
+/* Row list — same grammar as the room loot panel: name · weight · value · action. */
+.pack-row-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.pack-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+.pack-row-name {
+  color: var(--text);
+  border-bottom: 1px dotted var(--text-muted);
+  cursor: default;
+  width: fit-content;
+}
+.pack-row-weight,
+.pack-row-value {
+  text-align: right;
+  white-space: nowrap;
+}
+.pack-row-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.pack-row-note {
+  grid-column: 1 / -1;
+}
+.pack-empty { color: var(--text-muted); font-style: italic; margin: 4px 0; }
+
+.pack-vault-line { margin-top: 10px; }
+.pack-vault-label {
+  display: block;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  margin-bottom: 4px;
+}
+
+/* Before You Go — three solemn choices, one section. */
+.pack-vow-block { margin-top: 16px; }
+.pack-vow-heading {
+  color: var(--text-dim);
+  font-size: 0.86rem;
+  letter-spacing: 0.04em;
+  margin: 0 0 4px;
+}
+.pack-vow-fiction {
+  color: var(--text-dim);
+  font-style: italic;
+  margin: 0 0 8px;
+}
+.pack-vow-block + .pack-vow-block { margin-top: 20px; }

--- a/src/screens/StashScreen.tsx
+++ b/src/screens/StashScreen.tsx
@@ -1,18 +1,19 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { Button } from "../components/Button";
-import { Card } from "../components/Card";
 import { ItemComparePanel } from "../components/ItemComparePanel";
 import { ItemTooltip } from "../components/ItemTooltip";
 import { LoadoutBuilder } from "../components/LoadoutBuilder";
 import { MaterialInventory } from "../components/MaterialInventory";
 import { InsurancePanel, KeepsakePanel, RunPreparationPanel } from "../components/RunPreparationPanel";
+import { Tooltip } from "../components/Tooltip";
 import { calculateInventoryWeight } from "../game/inventory";
 import { getConsumableHealFormula } from "../game/itemEffects";
 import { getAvailableRunPreparationOptions, getInsuranceCost, getKeepsakeCandidates } from "../game/runPreparation";
 import type { EquipmentSlots, Inventory, ItemInstance } from "../game/types";
 import { useGameStore } from "../store/gameStore";
 import type { EquipmentChangePreview, EquipmentSlotName } from "../components/v04UiTypes";
+import "./StashScreen.css";
 
 export function StashScreen() {
   const stash = useGameStore(s => s.state.stash);
@@ -43,154 +44,100 @@ export function StashScreen() {
 
   const mode = activeCombat ? "combat" : activeRun ? "dungeon" : "village";
   const message = mode === "village" ? villageMessage : dungeonMessage;
-  const title = mode === "combat"
-    ? "Combat Inventory"
+
+  const eyebrow = mode === "combat" ? "In Combat" : mode === "dungeon" ? "On Delve" : "Village";
+  const scene = mode === "combat"
+    ? "No time to sort gear now. Only to use what's already in hand."
     : mode === "dungeon"
-      ? "Dungeon Inventory"
-      : "Inventory";
-  const subtitle = mode === "combat"
-    ? "Equipment changes are locked until the fight ends."
-    : mode === "dungeon"
-      ? "Manage only what you carried into this delve."
-      : "Prepare gear and supplies for the next delve.";
+      ? "The dark keeps its own ledger. This is what's left of what you brought."
+      : "The pack lies open on the table. The delve does not wait.";
+
+  const carryCapacity = player?.derivedStats.carryCapacity ?? 0;
+  const packedWeight = mode === "village"
+    ? calculateInventoryWeight(preparedInventory)
+    : activeRun ? calculateInventoryWeight(activeRun.raidInventory) : 0;
+  const displayedGold = mode === "village" ? stash.gold : activeRun?.raidInventory.gold ?? 0;
 
   return (
-    <div className="screen stash-screen">
-      <header className="stash-hero">
-        <div className="stash-hero-main">
-          <span className="stash-hero-eyebrow">{mode === "combat" ? "In Combat" : mode === "dungeon" ? "On Delve" : "Village"}</span>
-          <h1>{title}</h1>
-          <p className="muted">{subtitle}</p>
+    <div className="screen pack-screen">
+      <span className="pack-hero-eyebrow">{eyebrow}</span>
+      <p className="pack-hero-scene">{scene}</p>
+
+      {player && (
+        <div className="pack-status-line">
+          <span><em>{mode === "village" ? "Packed" : "Pack"}</em> {packedWeight} / {carryCapacity}</span>
+          <span><em>{mode === "village" ? "Stash" : "Gold"}</em> {displayedGold}g</span>
         </div>
-        {player && mode === "village" && (
-          <div className="stash-hero-meta">
-            <span><em>Stash</em> {stash.gold}g</span>
-            <span><em>Packed</em> {calculateInventoryWeight(preparedInventory)} / {player.derivedStats.carryCapacity}</span>
-          </div>
-        )}
-        {player && activeRun && mode !== "village" && (
-          <div className="stash-hero-meta">
-            <span><em>Carried</em> {activeRun.raidInventory.gold}g</span>
-            <span><em>Pack</em> {calculateInventoryWeight(activeRun.raidInventory)} / {player.derivedStats.carryCapacity}</span>
-          </div>
-        )}
-      </header>
+      )}
+
       {message && <p className="msg">{message}</p>}
-      <div className="stash-grid">
+
+      {player && (
+        <section className="pack-section" aria-label="What you wear">
+          <h2 className="pack-section-heading">What You Wear</h2>
+          <p className="pack-section-intro">
+            {mode === "combat"
+              ? "The fight is on. What's equipped stays equipped."
+              : "Every piece you carry on your body, weighed and ready."}
+          </p>
+          <LoadoutBuilder
+            character={player}
+            inventoryItems={mode === "village" ? stash.items : activeRun?.raidInventory.items}
+            activeRun={mode === "dungeon"}
+            readOnly={mode === "combat"}
+            preview={preview}
+            onPreview={(item, slot) => setPreview(previewEquipmentChange(item.instanceId, slot))}
+            onEquip={(item, slot) => {
+              genericEquip(item.instanceId, slot);
+              setPreview(undefined);
+            }}
+            onUnequip={slot => {
+              genericUnequip(slot);
+              setPreview(undefined);
+            }}
+          />
+          {mode !== "combat" && <ItemComparePanel preview={preview} />}
+        </section>
+      )}
+
+      <section className="pack-section" aria-label="What you carry down">
+        <h2 className="pack-section-heading">What You Carry Down</h2>
+        <p className="pack-section-intro">
+          {mode === "village"
+            ? "Everything staked on the next delve. Weight is the only honest limit."
+            : mode === "dungeon"
+              ? "What you're hauling out of the dark, if you make it."
+              : "Whatever's in the pack is whatever you've got."}
+        </p>
         {player && (
-          <Card title="Loadout" subtitle={mode === "combat" ? "View only" : `HP ${player.hp} / ${player.maxHp}`}>
-            <h4 className="muted">Equipped</h4>
-            <LoadoutBuilder
-              character={player}
-              inventoryItems={mode === "village" ? stash.items : activeRun?.raidInventory.items}
-              activeRun={mode === "dungeon"}
-              readOnly={mode === "combat"}
-              preview={preview}
-              onPreview={(item, slot) => setPreview(previewEquipmentChange(item.instanceId, slot))}
-              onEquip={(item, slot) => {
-                genericEquip(item.instanceId, slot);
-                setPreview(undefined);
-              }}
-              onUnequip={slot => {
-                genericUnequip(slot);
-                setPreview(undefined);
-              }}
-            />
-            {mode !== "combat" && <ItemComparePanel preview={preview} />}
-          </Card>
+          <WeightBar current={packedWeight} capacity={carryCapacity} />
         )}
 
-        {mode === "village" && (
-          <>
-            <Card title={`Next Raid Pack (${preparedInventory.gold} g)`} subtitle={player ? `${calculateInventoryWeight(preparedInventory)} / ${player.derivedStats.carryCapacity} weight` : undefined}>
-              {inventoryIsEmpty(preparedInventory) ? <div className="inv-empty">Nothing packed.</div> : (
-                <>
-                {hasMaterials(preparedInventory) && <MaterialInventory materials={preparedInventory.materials ?? {}} compact />}
-                <div className="inv-items">
-                  {preparedInventory.items.map(item => (
-                    <ItemActionCard
-                      key={item.instanceId}
-                      item={item}
-                      actions={<Button variant="ghost" onClick={() => unpackPreparedItem(item.instanceId)}>Unpack</Button>}
-                    />
-                  ))}
-                </div>
-                </>
-              )}
-            </Card>
-
-            <Card title={`Stash (${stash.gold} g)`}>
-              {inventoryIsEmpty(stash) ? <div className="inv-empty">Stash is bare.</div> : (
-                <>
-                {hasMaterials(stash) && <MaterialInventory materials={stash.materials ?? {}} compact />}
-                <div className="inv-items">
-                  {stash.items.map(item => (
-                    <ItemActionCard
-                      key={item.instanceId}
-                      item={item}
-                      actions={
-                        <>
-                          {getConsumableHealFormula(item) && (
-                            <Button variant="ghost" onClick={() => useStashItem(item.instanceId)}>Use</Button>
-                          )}
-                          {canEquip(item) && (
-                            <>
-                              <Button variant="ghost" onClick={() => setPreview(previewEquipmentChange(item.instanceId, preferredSlotFor(item, player?.equipped)))}>Preview</Button>
-                              <Button variant="ghost" onClick={() => equipStashItem(item.instanceId)}>Equip</Button>
-                            </>
-                          )}
-                          <Button variant="ghost" onClick={() => packPreparedItem(item.instanceId)}>Pack</Button>
-                        </>
-                      }
-                    />
-                  ))}
-                </div>
-                </>
-              )}
-            </Card>
-
-            <Card title="Run Preparations" subtitle="One-run advantages from village services">
-              <RunPreparationPanel
-                options={getAvailableRunPreparationOptions({ gameState: state })}
-                selectedPreparations={state.pendingRunPreparations ?? []}
-                npcs={state.village?.npcs ?? []}
-                onPurchase={(optionId, npcId) => purchasePreparation(npcId, optionId)}
-              />
-            </Card>
-
-            <Card title="Keepsake" subtitle="Survives even if you die below">
-              <KeepsakePanel
-                candidates={getKeepsakeCandidates(state)}
-                selectedInstanceId={state.pendingKeepsakeInstanceId}
-                onSelect={setKeepsake}
-                onClear={clearKeepsake}
-              />
-            </Card>
-
-            <Card title="Insurance" subtitle="Returns one equipped piece to the stash if you die">
-              <InsurancePanel
-                candidates={player ? (Object.values(player.equipped).filter(Boolean) as ItemInstance[]) : []}
-                selectedInstanceId={state.pendingInsuredInstanceId}
-                getCost={getInsuranceCost}
-                gold={stash.gold}
-                onInsure={purchaseInsurance}
-                onCancel={cancelInsurance}
-              />
-            </Card>
-          </>
-        )}
-
-        {(mode === "dungeon" || mode === "combat") && activeRun && (
-          <Card
-            title={`Raid Pack (${activeRun.raidInventory.gold} g)`}
-            subtitle={player ? `${calculateInventoryWeight(activeRun.raidInventory)} / ${player.derivedStats.carryCapacity} weight` : undefined}
-          >
-            {inventoryIsEmpty(activeRun.raidInventory) ? <div className="inv-empty">Empty for now.</div> : (
-              <>
-              {hasMaterials(activeRun.raidInventory) && <MaterialInventory materials={activeRun.raidInventory.materials ?? {}} compact />}
-              <div className="inv-items">
+        {mode === "village" ? (
+          inventoryIsEmpty(preparedInventory) ? (
+            <div className="pack-empty">Nothing packed.</div>
+          ) : (
+            <>
+              <ul className="pack-row-list">
+                {preparedInventory.items.map(item => (
+                  <PackRow
+                    key={item.instanceId}
+                    item={item}
+                    actions={<Button variant="ghost" onClick={() => unpackPreparedItem(item.instanceId)}>Unpack</Button>}
+                  />
+                ))}
+              </ul>
+              <VaultLine inventory={preparedInventory} />
+            </>
+          )
+        ) : activeRun ? (
+          inventoryIsEmpty(activeRun.raidInventory) ? (
+            <div className="pack-empty">Empty for now.</div>
+          ) : (
+            <>
+              <ul className="pack-row-list">
                 {activeRun.raidInventory.items.map(item => (
-                  <ItemActionCard
+                  <PackRow
                     key={item.instanceId}
                     item={item}
                     actions={
@@ -213,12 +160,114 @@ export function StashScreen() {
                     }
                   />
                 ))}
-              </div>
+              </ul>
+              <VaultLine inventory={activeRun.raidInventory} />
+            </>
+          )
+        ) : null}
+      </section>
+
+      {mode === "village" && (
+        <>
+          <section className="pack-section" aria-label="What stays home">
+            <h2 className="pack-section-heading">What Stays Home</h2>
+            <p className="pack-section-intro">The stash. Safe, and no use to you below.</p>
+            {inventoryIsEmpty(stash) ? (
+              <div className="pack-empty">Stash is bare.</div>
+            ) : (
+              <>
+                <ul className="pack-row-list">
+                  {stash.items.map(item => (
+                    <PackRow
+                      key={item.instanceId}
+                      item={item}
+                      actions={
+                        <>
+                          {getConsumableHealFormula(item) && (
+                            <Button variant="ghost" onClick={() => useStashItem(item.instanceId)}>Use</Button>
+                          )}
+                          {canEquip(item) && (
+                            <>
+                              <Button variant="ghost" onClick={() => setPreview(previewEquipmentChange(item.instanceId, preferredSlotFor(item, player?.equipped)))}>Preview</Button>
+                              <Button variant="ghost" onClick={() => equipStashItem(item.instanceId)}>Equip</Button>
+                            </>
+                          )}
+                          <Button variant="ghost" onClick={() => packPreparedItem(item.instanceId)}>Pack</Button>
+                        </>
+                      }
+                    />
+                  ))}
+                </ul>
+                <VaultLine inventory={stash} />
               </>
             )}
-          </Card>
-        )}
-      </div>
+          </section>
+
+          <section className="pack-section" aria-label="Before you go">
+            <h2 className="pack-section-heading">Before You Go</h2>
+
+            <div className="pack-vow-block">
+              <h3 className="pack-vow-heading">Run Preparations</h3>
+              <p className="pack-vow-fiction">A few coins spent in the village linger like luck once the dark closes in.</p>
+              <RunPreparationPanel
+                options={getAvailableRunPreparationOptions({ gameState: state })}
+                selectedPreparations={state.pendingRunPreparations ?? []}
+                npcs={state.village?.npcs ?? []}
+                onPurchase={(optionId, npcId) => purchasePreparation(npcId, optionId)}
+              />
+            </div>
+
+            <div className="pack-vow-block">
+              <h3 className="pack-vow-heading">Keepsake</h3>
+              <p className="pack-vow-fiction">One weightless thing, set aside. It survives even if you don't.</p>
+              <KeepsakePanel
+                candidates={getKeepsakeCandidates(state)}
+                selectedInstanceId={state.pendingKeepsakeInstanceId}
+                onSelect={setKeepsake}
+                onClear={clearKeepsake}
+              />
+            </div>
+
+            <div className="pack-vow-block">
+              <h3 className="pack-vow-heading">Insurance</h3>
+              <p className="pack-vow-fiction">Pay now, and grief costs less if the delve turns on you.</p>
+              <InsurancePanel
+                candidates={player ? (Object.values(player.equipped).filter(Boolean) as ItemInstance[]) : []}
+                selectedInstanceId={state.pendingInsuredInstanceId}
+                getCost={getInsuranceCost}
+                gold={stash.gold}
+                onInsure={purchaseInsurance}
+                onCancel={cancelInsurance}
+              />
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}
+
+function WeightBar({ current, capacity }: { current: number; capacity: number }) {
+  if (capacity <= 0) return null;
+  const pct = Math.min(100, Math.round((current / capacity) * 100));
+  const over = current > capacity;
+  const amber = !over && pct >= 85;
+  return (
+    <div className="pack-weight-bar" aria-label={`Weight ${current} of ${capacity}`}>
+      <span
+        className={`pack-weight-bar-fill ${over ? "pack-weight-over" : amber ? "pack-weight-amber" : ""}`}
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}
+
+function VaultLine({ inventory }: { inventory: Inventory }) {
+  if (!hasMaterials(inventory)) return null;
+  return (
+    <div className="pack-vault-line">
+      <span className="pack-vault-label">Vault</span>
+      <MaterialInventory materials={inventory.materials ?? {}} compact />
     </div>
   );
 }
@@ -232,12 +281,19 @@ function hasMaterials(inventory: Inventory): boolean {
   return Object.values(inventory.materials ?? {}).some(amount => amount && amount > 0);
 }
 
-function ItemActionCard({ item, actions }: { item: ItemInstance; actions: ReactNode }) {
+function PackRow({ item, actions }: { item: ItemInstance; actions: ReactNode }) {
   return (
-    <div className="item-action-card">
-      <ItemTooltip item={item} />
-      <div className="item-actions">{actions}</div>
-    </div>
+    <li className="pack-row">
+      <Tooltip content={<ItemTooltip item={item} />} as="span">
+        <span className="pack-row-name">
+          {item.name}
+          {item.quantity > 1 && <span className="muted small"> x{item.quantity}</span>}
+        </span>
+      </Tooltip>
+      <span className="pack-row-weight muted small">{item.weight * item.quantity}w</span>
+      <span className="pack-row-value muted small">{item.value * item.quantity}g</span>
+      <span className="pack-row-actions">{actions}</span>
+    </li>
   );
 }
 


### PR DESCRIPTION
Closes #28.

- Six dashboard cards -> narrative column: What You Wear / What You Carry Down / What Stays Home / Before You Go
- Loadout as compact slot rows (LoadoutBuilder restyled, API unchanged); raid pack + stash as loot-panel-style rows; slim weight bar (amber >=85%, red over cap)
- Keepsake / Insurance / Preparations as vow rows with one line of fiction each
- Combat view-only mode gating preserved exactly
- Co-located CSS; index.css/store/game untouched; ItemCard/InventoryList untouched (unused by this screen)

229/229 tests, typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)