### PR TITLE
Character screen as the chronicle's record of you

### DIFF
--- a/src/components/BuildSummaryPanel.css
+++ b/src/components/BuildSummaryPanel.css
@@ -1,0 +1,35 @@
+/* Build summary — collapsed to a single quiet "in sum" line under the
+   measure, plus any warnings that still need a reader's attention. */
+
+.build-in-sum { margin-top: 10px; }
+
+.build-in-sum-line {
+  color: var(--text-dim);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin: 0;
+}
+.build-in-sum-eyebrow {
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-right: 4px;
+}
+.build-in-sum-scores { font-variant-numeric: tabular-nums; }
+.build-score-inline { color: var(--text-muted); }
+.build-score-inline strong { color: var(--text); font-weight: 600; }
+.build-score-inline strong.danger { color: var(--danger); }
+
+.build-warnings {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.build-warning { font-size: 0.88rem; font-style: italic; }
+.build-warning-info { color: var(--text-dim); }
+.build-warning-warning { color: var(--warn); }
+.build-warning-danger { color: var(--danger); }

--- a/src/components/BuildSummaryPanel.tsx
+++ b/src/components/BuildSummaryPanel.tsx
@@ -1,4 +1,5 @@
 import type { BuildSummary } from "./v04UiTypes";
+import "./BuildSummaryPanel.css";
 
 export interface BuildSummaryPanelProps {
   summary: BuildSummary;
@@ -6,23 +7,25 @@ export interface BuildSummaryPanelProps {
 
 export function BuildSummaryPanel({ summary }: BuildSummaryPanelProps) {
   return (
-    <section className="build-summary-panel">
-      <header>
-        <span className="muted small">Build Identity</span>
-        <div className="build-tag-row">
-          {summary.primaryTags.length === 0
-            ? <span className="build-tag">Unfocused</span>
-            : summary.primaryTags.map(tag => <span className="build-tag" key={tag}>{formatTag(tag)}</span>)}
-        </div>
-      </header>
-      <div className="build-score-grid">
-        <Score label="Combat" value={summary.combatPowerScore} />
-        <Score label="Explore" value={summary.explorationScore} />
-        <Score label="Extract" value={summary.extractionSafetyScore} />
-        <Score label="Risk" value={summary.riskScore} risk />
-      </div>
+    <section className="build-in-sum">
+      <p className="build-in-sum-line">
+        <span className="build-in-sum-eyebrow">In sum</span>{" "}
+        {summary.primaryTags.length === 0
+          ? "unfocused"
+          : summary.primaryTags.map(formatTag).join(", ")}
+        <span className="build-in-sum-scores">
+          {" — "}
+          <Score label="Combat" value={summary.combatPowerScore} />
+          {" · "}
+          <Score label="Explore" value={summary.explorationScore} />
+          {" · "}
+          <Score label="Extract" value={summary.extractionSafetyScore} />
+          {" · "}
+          <Score label="Risk" value={summary.riskScore} risk />
+        </span>
+      </p>
       {summary.warnings.length > 0 && (
-        <ul className="build-warning-list">
+        <ul className="build-warnings">
           {summary.warnings.map((warning, index) => (
             <li key={`${warning.type}-${index}`} className={`build-warning build-warning-${warning.severity}`}>
               {warning.message}
@@ -35,16 +38,13 @@ export function BuildSummaryPanel({ summary }: BuildSummaryPanelProps) {
 }
 
 function Score({ label, value, risk }: { label: string; value: number; risk?: boolean }) {
-  const clamped = Math.max(0, Math.min(12, value));
   return (
-    <div className="build-score">
-      <span>{label}</span>
-      <strong className={risk && value >= 4 ? "danger" : undefined}>{value}</strong>
-      <div className="build-score-track"><span style={{ width: `${Math.round((clamped / 12) * 100)}%` }} /></div>
-    </div>
+    <span className="build-score-inline">
+      {label} <strong className={risk && value >= 4 ? "danger" : undefined}>{value}</strong>
+    </span>
   );
 }
 
 function formatTag(tag: string): string {
-  return tag.replace(/([A-Z])/g, " $1").replace(/^./, c => c.toUpperCase());
+  return tag.replace(/([A-Z])/g, " $1").replace(/^./, c => c.toUpperCase()).toLowerCase();
 }

--- a/src/components/StatBlock.css
+++ b/src/components/StatBlock.css
@@ -1,0 +1,43 @@
+/* Stat block — the record's "measure", a clean two-column ledger rather
+   than a card grid. Prominent combat stats get their own emphasized row;
+   everything else (secondary stats + abilities) reads as a quiet table. */
+
+.stat-ledger { display: flex; flex-direction: column; gap: 16px; }
+
+.stat-ledger-prominent {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px 20px;
+  padding: 14px 16px;
+  border: 1px solid var(--warm-line);
+  border-radius: 8px;
+  background: var(--warm-bg);
+}
+.stat-ledger-prominent .stat-entry-value { font-size: 1.3rem; color: var(--accent-2); }
+
+.stat-ledger-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 6px 20px;
+}
+
+.stat-entry {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 2px 0;
+}
+.stat-entry-prominent { flex-direction: column; gap: 2px; }
+
+.stat-entry-label {
+  font-size: 0.74rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  cursor: help;
+}
+.stat-entry-value {
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}

--- a/src/components/StatBlock.tsx
+++ b/src/components/StatBlock.tsx
@@ -1,6 +1,7 @@
 import type { Character } from "../game/types";
 import { ABILITY_NAMES } from "../game/constants";
 import type { AbilityName } from "../game/types";
+import "./StatBlock.css";
 
 interface Props {
   character: Character;
@@ -9,24 +10,23 @@ interface Props {
 export function StatBlock({ character }: Props) {
   const ds = character.derivedStats;
   return (
-    <div className="stat-block">
-      <div className="stat-row">
-        <StatLabel label="HP" tip="Current health. At zero, the run ends and carried gear is lost." /><strong>{character.hp} / {character.maxHp}</strong>
+    <div className="stat-ledger">
+      <div className="stat-ledger-prominent">
+        <StatEntry label="HP" tip="Current health. At zero, the run ends and carried gear is lost." value={`${character.hp} / ${character.maxHp}`} prominent />
+        <StatEntry label="Armor" tip="Reduces incoming hit damage after an enemy connects." value={ds.armor} prominent />
+        <StatEntry label="Accuracy" tip="Added to attack rolls against enemy evasion." value={`+${ds.accuracy}`} prominent />
+        <StatEntry label="Evasion" tip="Enemy attacks must meet or beat this value to hit." value={ds.evasion} prominent />
+        <StatEntry label="Carry" tip="Maximum raid-pack weight before you must leave loot behind." value={ds.carryCapacity} prominent />
       </div>
-      <div className="stat-row"><StatLabel label="Armor" tip="Reduces incoming hit damage after an enemy connects." /><strong>{ds.armor}</strong></div>
-      <div className="stat-row"><StatLabel label="Accuracy" tip="Added to attack rolls against enemy evasion." /><strong>+{ds.accuracy}</strong></div>
-      <div className="stat-row"><StatLabel label="Evasion" tip="Enemy attacks must meet or beat this value to hit." /><strong>{ds.evasion}</strong></div>
-      <div className="stat-row"><StatLabel label="Crit %" tip="Critical-hit bonus from gear and traits." /><strong>{ds.critChance}%</strong></div>
-      <div className="stat-row"><StatLabel label="Carry" tip="Maximum raid-pack weight before you must leave loot behind." /><strong>{ds.carryCapacity}</strong></div>
-      <div className="stat-row"><StatLabel label="Magic" tip="Power for magical gear and future spell effects." /><strong>{ds.magicPower}</strong></div>
-      <div className="stat-row"><StatLabel label="Trap Sense" tip="Added to trap checks when entering trapped rooms." /><strong>{ds.trapSense}</strong></div>
-      <div className="stat-divider" />
-      {ABILITY_NAMES.map(a => (
-        <div className="stat-row" key={a}>
-          <StatLabel label={a} tip={ABILITY_TIPS[a]} capitalize />
-          <strong>{character.abilityScores[a]}</strong>
-        </div>
-      ))}
+
+      <div className="stat-ledger-grid">
+        <StatEntry label="Crit %" tip="Critical-hit bonus from gear and traits." value={`${ds.critChance}%`} />
+        <StatEntry label="Magic" tip="Power for magical gear and future spell effects." value={ds.magicPower} />
+        <StatEntry label="Trap Sense" tip="Added to trap checks when entering trapped rooms." value={ds.trapSense} />
+        {ABILITY_NAMES.map(a => (
+          <StatEntry key={a} label={a} tip={ABILITY_TIPS[a]} value={character.abilityScores[a]} capitalize />
+        ))}
+      </div>
     </div>
   );
 }
@@ -40,14 +40,23 @@ const ABILITY_TIPS: Record<AbilityName, string> = {
   presence: "Feeds social and future leadership effects."
 };
 
-function StatLabel({ label, tip, capitalize }: { label: string; tip: string; capitalize?: boolean }) {
+function StatEntry({ label, tip, value, capitalize, prominent }: {
+  label: string;
+  tip: string;
+  value: string | number;
+  capitalize?: boolean;
+  prominent?: boolean;
+}) {
   return (
-    <span
-      className="stat-label-help"
-      style={capitalize ? { textTransform: "capitalize" } : undefined}
-      title={tip}
-    >
-      {label}
-    </span>
+    <div className={`stat-entry${prominent ? " stat-entry-prominent" : ""}`}>
+      <span
+        className="stat-entry-label"
+        style={capitalize ? { textTransform: "capitalize" } : undefined}
+        title={tip}
+      >
+        {label}
+      </span>
+      <strong className="stat-entry-value">{value}</strong>
+    </div>
   );
 }

--- a/src/components/TalentNodeCard.css
+++ b/src/components/TalentNodeCard.css
@@ -1,0 +1,82 @@
+/* A single learned deed — styled as a ledger entry, not a skill-tree node.
+   Status reads from a left rule and a small-caps tag: learned entries are
+   settled fact, available entries invite action, locked entries recede. */
+
+.deed-entry {
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--line);
+  border-radius: 6px;
+  padding: 12px 16px;
+  background: var(--bg-1);
+}
+.deed-entry-learned {
+  border-left-color: var(--accent-2);
+  background: rgba(216, 178, 92, 0.05);
+}
+.deed-entry-available { border-left-color: var(--good); }
+.deed-entry-locked { opacity: 0.6; }
+
+.deed-entry-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.deed-entry-kicker {
+  display: block;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+}
+.deed-entry-name { margin: 0; font-size: 1.05rem; }
+
+.deed-entry-status {
+  flex: 0 0 auto;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  color: var(--text-muted);
+}
+.deed-entry-status[data-status="learned"] { color: var(--accent-2); }
+.deed-entry-status[data-status="available"] { color: var(--good); }
+
+.deed-entry-desc { margin: 8px 0 0; color: var(--text-dim); }
+
+.deed-entry-effects {
+  margin: 8px 0 0;
+  padding-left: 1.2em;
+  color: var(--text-dim);
+  font-size: 0.9rem;
+}
+
+.deed-entry-reqs {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+.deed-entry-reqs code {
+  background: var(--bg-2);
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+
+.deed-entry-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 10px;
+}
+.deed-entry-cost {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+.deed-entry-reason { margin: 6px 0 0; }

--- a/src/components/TalentNodeCard.tsx
+++ b/src/components/TalentNodeCard.tsx
@@ -1,5 +1,12 @@
 import { Button } from "./Button";
 import type { TalentNodeDefinition, TalentUnlockStatus } from "./v04UiTypes";
+import "./TalentNodeCard.css";
+
+const STATUS_LABELS: Record<TalentUnlockStatus, string> = {
+  learned: "Learned",
+  available: "Available",
+  locked: "Locked"
+};
 
 export interface TalentNodeCardProps {
   talent: TalentNodeDefinition;
@@ -11,22 +18,22 @@ export interface TalentNodeCardProps {
 
 export function TalentNodeCard({ talent, status, canLearn, reason, onLearn }: TalentNodeCardProps) {
   return (
-    <article className={`talent-node-card talent-node-${status}`}>
-      <header className="talent-node-header">
+    <article className={`deed-entry deed-entry-${status}`}>
+      <header className="deed-entry-header">
         <div>
-          <span className="talent-node-kicker">Tier {talent.tier} · {talent.type}</span>
-          <h3>{talent.name}</h3>
+          <span className="deed-entry-kicker">Tier {talent.tier} · {talent.type}</span>
+          <h3 className="deed-entry-name">{talent.name}</h3>
         </div>
-        <span className="talent-node-cost">{talent.cost} TP</span>
+        <span className="deed-entry-status" data-status={status}>{STATUS_LABELS[status]}</span>
       </header>
-      <p>{talent.description}</p>
-      <ul className="talent-node-effects">
+      <p className="deed-entry-desc">{talent.description}</p>
+      <ul className="deed-entry-effects">
         {talent.effects.map((effect, index) => (
           <li key={`${talent.id}-effect-${index}`}>{effect.description}</li>
         ))}
       </ul>
       {(talent.requirements?.length ?? 0) > 0 && (
-        <div className="talent-node-reqs">
+        <div className="deed-entry-reqs">
           <span>Requires</span>
           {talent.requirements!.map((requirement, index) => (
             <code key={`${talent.id}-req-${index}`}>
@@ -35,8 +42,8 @@ export function TalentNodeCard({ talent, status, canLearn, reason, onLearn }: Ta
           ))}
         </div>
       )}
-      <footer className="talent-node-footer">
-        <span className={`talent-status talent-status-${status}`}>{status}</span>
+      <footer className="deed-entry-footer">
+        <span className="deed-entry-cost">{talent.cost} TP</span>
         {status === "learned" ? (
           <span className="muted small">Known</span>
         ) : (
@@ -45,7 +52,7 @@ export function TalentNodeCard({ talent, status, canLearn, reason, onLearn }: Ta
           </Button>
         )}
       </footer>
-      {!canLearn && status !== "learned" && reason && <p className="muted small">{reason}</p>}
+      {!canLearn && status !== "learned" && reason && <p className="muted small deed-entry-reason">{reason}</p>}
     </article>
   );
 }

--- a/src/components/TalentPointSummary.css
+++ b/src/components/TalentPointSummary.css
@@ -1,0 +1,22 @@
+/* Talent point summary — quiet inline tally, small caps over tabular numerals. */
+
+.deed-tally { display: flex; gap: 16px; }
+
+.deed-tally-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-start;
+}
+.deed-tally-cell span {
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.deed-tally-cell strong {
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+.deed-tally-cell strong.good { color: var(--good); }
+.deed-tally-cell strong.muted { color: var(--text-muted); }

--- a/src/components/TalentPointSummary.tsx
+++ b/src/components/TalentPointSummary.tsx
@@ -1,5 +1,6 @@
 import type { Character } from "../game/types";
 import type { CharacterWithProgression } from "./v04UiTypes";
+import "./TalentPointSummary.css";
 
 interface TalentPointSummaryProps {
   character: Character;
@@ -12,7 +13,7 @@ export function TalentPointSummary({ character }: TalentPointSummaryProps) {
   const active = progression?.activeCombatActionIds.length ?? 0;
 
   return (
-    <div className="talent-point-summary">
+    <div className="deed-tally">
       <SummaryCell label="Unspent" value={unspent} tone={unspent > 0 ? "good" : "muted"} />
       <SummaryCell label="Spent" value={spent} />
       <SummaryCell label="Actions" value={`${active}/3`} />
@@ -22,7 +23,7 @@ export function TalentPointSummary({ character }: TalentPointSummaryProps) {
 
 function SummaryCell({ label, value, tone }: { label: string; value: number | string; tone?: "good" | "muted" }) {
   return (
-    <div className="talent-point-cell">
+    <div className="deed-tally-cell">
       <span>{label}</span>
       <strong className={tone}>{value}</strong>
     </div>

--- a/src/components/TalentTreePanel.css
+++ b/src/components/TalentTreePanel.css
@@ -1,0 +1,19 @@
+/* Talent tree — tiers of learned deeds rather than a skill-tree widget. */
+
+.talent-tree-panel { display: flex; flex-direction: column; gap: 20px; }
+
+.deed-tier-stack { display: flex; flex-direction: column; gap: 20px; }
+
+.deed-tier { display: flex; flex-direction: column; gap: 10px; }
+.deed-tier-heading {
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0;
+}
+.deed-tier-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/src/components/TalentTreePanel.tsx
+++ b/src/components/TalentTreePanel.tsx
@@ -3,23 +3,18 @@ import { canLearnTalent, getTalentStatus } from "../game/talents";
 import type {
   TalentTreePanelProps,
 } from "./v04UiTypes";
+import "./TalentTreePanel.css";
 
 export function TalentTreePanel({ character, tree, village, onLearnTalent }: TalentTreePanelProps) {
   const tiers = [...new Set(tree.nodes.map(node => node.tier))].sort((a, b) => a - b);
 
   return (
     <section className="talent-tree-panel">
-      <header className="talent-tree-head">
-        <div>
-          <h2>{tree.name}</h2>
-          <p className="muted">{tree.description}</p>
-        </div>
-      </header>
-      <div className="talent-tier-stack">
+      <div className="deed-tier-stack">
         {tiers.map(tier => (
-          <section key={tier} className="talent-tier">
-            <h3>Tier {tier}</h3>
-            <div className="talent-tier-grid">
+          <section key={tier} className="deed-tier">
+            <h3 className="deed-tier-heading">Tier {tier}</h3>
+            <div className="deed-tier-grid">
               {tree.nodes.filter(node => node.tier === tier).map(node => {
                 const status = getTalentStatus({ character, talent: node, village });
                 const learn = canLearnTalent({ character, talentId: node.id, village });

--- a/src/screens/CharacterScreen.css
+++ b/src/screens/CharacterScreen.css
@@ -1,0 +1,64 @@
+/* Character screen — the chronicle's living entry on you. Same 70ch
+   narrative column as village/dungeon/creation; the record continues the
+   "first entry" written at character creation rather than a stat-admin page. */
+
+.character-screen-prose { padding: 14px 24px 20px; display: flex; flex-direction: column; gap: 0; }
+
+.chronicle-eyebrow {
+  display: block;
+  font-size: 0.74rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.chronicle-name { margin: 0 0 8px; font-size: 2rem; }
+
+.chronicle-lede {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--text);
+  margin: 0 0 14px;
+}
+
+.chronicle-hp-row { margin-bottom: 18px; }
+
+.chronicle-delve-note {
+  border: 1px solid var(--warm-line);
+  border-radius: 8px;
+  padding: 10px 16px;
+  margin-bottom: 20px;
+  background: var(--warm-bg);
+}
+.chronicle-delve-note-title {
+  font-size: 0.74rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+}
+.chronicle-delve-note-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 18px;
+  margin-top: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.chronicle-delve-note-meta em {
+  font-style: normal;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  margin-right: 4px;
+}
+
+.chronicle-section { margin-top: 8px; margin-bottom: 28px; }
+.chronicle-section-heading {
+  font-size: 0.9rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+  margin: 0 0 12px;
+}
+.chronicle-section-note { margin: -6px 0 10px; }

--- a/src/screens/CharacterScreen.tsx
+++ b/src/screens/CharacterScreen.tsx
@@ -1,23 +1,26 @@
-import { useState } from "react";
-import { Card } from "../components/Card";
 import { BuildSummaryPanel } from "../components/BuildSummaryPanel";
-import { Button } from "../components/Button";
 import { LoadoutBuilder } from "../components/LoadoutBuilder";
 import { StatBlock } from "../components/StatBlock";
-import { TalentPointSummary } from "../components/TalentPointSummary";
 import { useGameStore } from "../store/gameStore";
 import { TalentScreen } from "./TalentScreen";
 import { getAncestry } from "../data/ancestries";
 import { getClass } from "../data/classes";
 import { generateBuildSummary } from "../game/buildMath";
+import type { Character, VillageState } from "../game/types";
+import "./CharacterScreen.css";
+
+const ORDINALS = [
+  "First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh", "Eighth",
+  "Ninth", "Tenth", "Eleventh", "Twelfth"
+];
 
 export function CharacterScreen() {
   const player = useGameStore(s => s.state.player);
   const run = useGameStore(s => s.state.activeRun);
   const village = useGameStore(s => s.state.village);
+  const runSummaries = useGameStore(s => s.state.runSummaries);
   const learnTalent = useGameStore(s => s.learnTalent);
   const refundTalents = useGameStore(s => s.refundTalents);
-  const [showTalents, setShowTalents] = useState(false);
 
   if (!player) return <div className="screen">No character.</div>;
 
@@ -27,68 +30,100 @@ export function CharacterScreen() {
     ancestry: getAncestry(player.ancestryId),
     classDefinition: getClass(player.classId)
   });
-
-  if (showTalents) {
-    return (
-      <div className="screen character-screen">
-        <TalentScreen
-          character={player}
-          village={village}
-          onLearnTalent={learnTalent}
-          onRefundTalents={refundTalents}
-          onClose={() => setShowTalents(false)}
-        />
-      </div>
-    );
-  }
+  const entry = composeChronicleEntry(player, village, runSummaries.length,
+    runSummaries.filter(r => r.reason === "dead").length);
 
   return (
-    <div className="screen character-screen">
-      <header className="character-hero">
-        <div className="character-hero-main">
-          <span className="character-hero-eyebrow">Level {player.level} {capitalize(player.ancestryId)} {capitalize(player.classId)}</span>
-          <h1>{player.name}</h1>
-          <div className="character-hero-hp">
+    <div className="screen character-screen character-screen-prose">
+      <div className="narrative-scroll">
+        <div className="narrative-column">
+          <span className="chronicle-eyebrow">{entry.eyebrow}</span>
+          <h1 className="chronicle-name">{player.name}</h1>
+          <p className="chronicle-lede">{entry.lede}</p>
+
+          <div className="chronicle-hp-row">
             <div className={`hp-bar ${hpPct <= 25 ? "hp-bar-low" : hpPct <= 50 ? "hp-bar-mid" : ""}`} style={{ maxWidth: 320 }}>
               <div className="hp-bar-fill" style={{ width: `${hpPct}%` }} />
               <span className="hp-bar-label">HP {player.hp} / {player.maxHp}</span>
             </div>
-            <span className="muted small">{player.xp} XP</span>
           </div>
-          <div className="character-hero-actions">
-            <TalentPointSummary character={player} />
-            <Button variant="secondary" onClick={() => setShowTalents(true)}>Talents</Button>
-          </div>
-        </div>
-        {run && (
-          <div className="character-hero-delve">
-            <span className="delve-hero-place-name">On Delve</span>
-            <div className="character-delve-meta">
-              <span><em>Depth</em> {run.tier}</span>
-              <span><em>Charted</em> {run.visitedRoomIds.length} / {run.roomGraph.length}</span>
-              <span><em>Carried</em> {run.raidInventory.gold} g</span>
+
+          {run && (
+            <div className="chronicle-delve-note">
+              <span className="chronicle-delve-note-title">Mid-Delve</span>
+              <div className="chronicle-delve-note-meta muted small">
+                <span><em>Depth</em> {run.tier}</span>
+                <span><em>Charted</em> {run.visitedRoomIds.length} / {run.roomGraph.length}</span>
+                <span><em>Carried</em> {run.raidInventory.gold} g</span>
+              </div>
             </div>
-          </div>
-        )}
-      </header>
+          )}
 
-      <div className="character-grid">
-        <Card title="Stats">
-          <StatBlock character={player} />
-        </Card>
+          <section className="chronicle-section" aria-label="Your measure">
+            <h2 className="chronicle-section-heading">Your Measure</h2>
+            <StatBlock character={player} />
+            <BuildSummaryPanel summary={summary} />
+          </section>
 
-        <Card title="Build Summary" subtitle="Stats, gear risk, and class identity">
-          <BuildSummaryPanel summary={summary} />
-        </Card>
+          <section className="chronicle-section" aria-label="What you wear">
+            <h2 className="chronicle-section-heading">What You Wear</h2>
+            <p className="chronicle-section-note muted small">
+              {run ? "At risk until extraction." : "Safe in the village."}
+            </p>
+            <LoadoutBuilder character={player} readOnly activeRun={Boolean(run)} />
+          </section>
 
-        <Card title="Loadout" subtitle={run ? "At risk until extraction" : "Safe in the village"}>
-          <LoadoutBuilder character={player} readOnly activeRun={Boolean(run)} />
-        </Card>
+          <section className="chronicle-section" aria-label="What you have learned">
+            <h2 className="chronicle-section-heading">What You Have Learned</h2>
+            <TalentScreen
+              character={player}
+              village={village}
+              onLearnTalent={learnTalent}
+              onRefundTalents={refundTalents}
+            />
+          </section>
+        </div>
       </div>
     </div>
   );
 }
 
-function capitalize(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1);
+function ordinal(level: number): string {
+  return ORDINALS[level - 1] ?? `${level}th`;
+}
+
+function composeChronicleEntry(
+  player: Character,
+  village: VillageState | undefined,
+  delveCount: number,
+  deathCount: number
+): { eyebrow: string; lede: string } {
+  const ancestryName = getAncestry(player.ancestryId).name;
+  const className = getClass(player.classId).name;
+  const xpToNext = 100 + (player.level - 1) * 60;
+
+  const eyebrow = village
+    ? `${ordinal(player.level)} season in ${village.name}`
+    : `${ordinal(player.level)} season`;
+
+  const sentences: string[] = [];
+  sentences.push(`${ancestryName} ${className.toLowerCase()}.`);
+
+  if (delveCount === 0) {
+    sentences.push("The chronicle has yet to record a delve.");
+  } else {
+    const delveWord = delveCount === 1 ? "delve" : "delves";
+    const deathClause = deathCount > 0
+      ? `, ${deathCount} death${deathCount === 1 ? "" : "s"} weathered`
+      : "";
+    sentences.push(`The chronicle records ${delveCount} ${delveWord}${deathClause}.`);
+  }
+
+  sentences.push(`${player.xp} of ${xpToNext} experience toward the next season.`);
+
+  if (village && village.renown > 0) {
+    sentences.push(`Renown ${village.renown} among its people.`);
+  }
+
+  return { eyebrow, lede: sentences.join(" ") };
 }

--- a/src/screens/CharacterScreen.tsx
+++ b/src/screens/CharacterScreen.tsx
@@ -6,7 +6,9 @@ import { TalentScreen } from "./TalentScreen";
 import { getAncestry } from "../data/ancestries";
 import { getClass } from "../data/classes";
 import { generateBuildSummary } from "../game/buildMath";
-import type { Character, VillageState } from "../game/types";
+import { getXpRequiredForLevel } from "../game/characterProgression";
+import { CHARACTER_PROGRESSION_RULES } from "../game/constants";
+import type { Character, CharacterLevel, VillageState } from "../game/types";
 import "./CharacterScreen.css";
 
 const ORDINALS = [
@@ -100,7 +102,10 @@ function composeChronicleEntry(
 ): { eyebrow: string; lede: string } {
   const ancestryName = getAncestry(player.ancestryId).name;
   const className = getClass(player.classId).name;
-  const xpToNext = 100 + (player.level - 1) * 60;
+  const atMaxLevel = player.level >= CHARACTER_PROGRESSION_RULES.maxLevel;
+  const xpToNext = atMaxLevel
+    ? undefined
+    : getXpRequiredForLevel((player.level + 1) as CharacterLevel);
 
   const eyebrow = village
     ? `${ordinal(player.level)} season in ${village.name}`
@@ -119,7 +124,11 @@ function composeChronicleEntry(
     sentences.push(`The chronicle records ${delveCount} ${delveWord}${deathClause}.`);
   }
 
-  sentences.push(`${player.xp} of ${xpToNext} experience toward the next season.`);
+  if (xpToNext === undefined) {
+    sentences.push("The measure is full; the chronicle has nothing further to ask of you.");
+  } else {
+    sentences.push(`${player.xp} of ${xpToNext} experience toward the next season.`);
+  }
 
   if (village && village.renown > 0) {
     sentences.push(`Renown ${village.renown} among its people.`);

--- a/src/screens/TalentScreen.css
+++ b/src/screens/TalentScreen.css
@@ -1,0 +1,23 @@
+/* Talents, embedded as the chronicle's "what you have learned" section
+   rather than a standalone skill-tree screen. */
+
+.learned-deeds { display: flex; flex-direction: column; gap: 16px; }
+
+.learned-deeds-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.learned-deeds-desc {
+  margin: 4px 0 0;
+  color: var(--text-dim);
+  max-width: 52ch;
+}
+.learned-deeds-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}

--- a/src/screens/TalentScreen.tsx
+++ b/src/screens/TalentScreen.tsx
@@ -1,9 +1,9 @@
 import { Button } from "../components/Button";
-import { Card } from "../components/Card";
 import { TalentPointSummary } from "../components/TalentPointSummary";
 import { TalentTreePanel } from "../components/TalentTreePanel";
 import type { Character, VillageState } from "../game/types";
 import { getTalentTreeForClass } from "../game/talents";
+import "./TalentScreen.css";
 
 interface TalentScreenProps {
   character: Character;
@@ -16,26 +16,24 @@ interface TalentScreenProps {
 export function TalentScreen({ character, village, onLearnTalent, onRefundTalents, onClose }: TalentScreenProps) {
   const tree = getTalentTreeForClass(character.classId);
   return (
-    <div className="talent-screen">
-      <header className="talent-screen-header">
+    <div className="learned-deeds">
+      <header className="learned-deeds-header">
         <div>
-          <span className="muted small">{formatLabel(character.classId)} progression</span>
-          <h1>Talents</h1>
+          <span className="muted small">{formatLabel(character.classId)} · {tree.name}</span>
+          <p className="learned-deeds-desc">{tree.description}</p>
         </div>
-        <div className="talent-screen-actions">
+        <div className="learned-deeds-actions">
           <TalentPointSummary character={character} />
-          <Button variant="ghost" onClick={onRefundTalents}>Refund</Button>
+          <Button variant="ghost" onClick={onRefundTalents}>Unlearn All</Button>
           {onClose && <Button variant="secondary" onClick={onClose}>Back</Button>}
         </div>
       </header>
-      <Card title={tree.name} subtitle="Small class tree for v0.4 build identity">
-        <TalentTreePanel
-          character={character}
-          tree={tree}
-          village={village}
-          onLearnTalent={onLearnTalent}
-        />
-      </Card>
+      <TalentTreePanel
+        character={character}
+        tree={tree}
+        village={village}
+        onLearnTalent={onLearnTalent}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Closes #29.

- Opens in prose composed only from tracked state: ancestry/class, delve/death tally from runSummaries, XP toward next level, renown; honest empty state for new characters
- Your Measure: StatBlock as a two-column ledger (prominent combat row + quiet tabular grid); BuildSummaryPanel as a single In-sum line
- What You Wear: LoadoutBuilder consumed with identical props
- What You Have Learned: talent tree restyled as deed entries, now permanently inline (replaces the old full-screen toggle; no handler dropped)
- Renamed new class names that collided with legacy index.css rules; verified uniqueness in dist

229/229 tests, typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)