### PR TITLE
The Delve v0.5: authored places, oil clock, positional hunters, inline encounters

### DIFF
--- a/docs/design/the-delve.md
+++ b/docs/design/the-delve.md
@@ -1,0 +1,107 @@
+# The Delve — v0.5 structural rebuild
+
+**The fantasy:** you are somewhere you shouldn't be, carrying things you can't
+afford to lose, and everything you do makes noise.
+
+Tarkov runs on three currencies — time, noise, space. The current game has
+noise (threat score) and space (pack weight) but no time, its threat is a
+number when dread needs a *where*, and its procgen mazes mean no run ever
+teaches you anything. v0.5 rebuilds the run layer around five pillars.
+Everything outside the run layer (items, affixes, loot tables, talents,
+crafting, village, quests, character math, saves) survives as-is.
+
+## Pillar 1 — Place, not maze
+
+Dungeons are hand-authored, fixed, learnable. A *place* has a name, ~25–30
+rooms with stable layout and landmark rooms, one-way shortcuts, and multiple
+extraction points with conditions. Procedural per run: loot spawns, inhabitant
+count and placement, which doors are locked/jammed, event placement, supply
+caches. Runs accumulate into player knowledge; the cartographer finally
+matters (see Pillar 4 UI: the map is an item).
+
+First authored place: **the Goblin Warrens**, reworked from the existing biome
+(keep its prose voice: stolen lumber, tallow, cheap glass). Two floors for
+v0.5. Extracts on floor 1: (a) *the way you came* — bars shut when the place
+reaches Hunting alertness; (b) *the flooded stair* — usable only while the
+water-clock holds (a run-scoped countdown); (c) *the rope winch* — slow and
+loud: three actions of cranking, each a noise event.
+
+## Pillar 2 — The lamp is the clock
+
+The player carries a lamp with an oil track (default capacity 20). Actions
+burn oil: move 1, search 2, listen 1, encounter beat 1, disarm 2, winch crank
+1. Oil flasks (weight 2, refill 20) compete with loot for pack space and are
+bought at the village / packed in the ritual.
+
+Light states: **bright** (normal) → **dim** (last 25% of current fill:
+search yields worse, hunters bolder) → **dark** (no oil: cannot search or
+read the map, move noise doubles, encounter decisions lose the sneak option).
+Darkness never hard-fails the run — it multiplies everything bad.
+
+## Pillar 3 — Threat has an address
+
+Each run seeds 4–6 **hunters** (from the existing bestiary) at authored spawn
+rooms. After every player action the simulation ticks: hunters move 0–1 rooms.
+States: `dormant` (fixed) → `roaming` (drifts randomly) → `drawn` (moves
+toward the last noise it heard) → `hunting` (knows your room, converges).
+
+**Noise** events have loudness; they propagate along the room graph and a
+hunter hears one if `loudness ≥ graph distance`. Move = 1 (+1 if pack over
+60% capacity, +1 more in the dark), search = 2, fight beat = 3, chest/lock
+work = 3, flee = 4, winch crank = 4. The player hears hunters within 2 rooms
+as directional prose: "Something drags itself along the west gallery."
+
+The old threat meter survives as **alertness** — how awake the place is. It
+rises from noise, drives reinforcement spawns at thresholds, hunter boldness,
+and extract conditions (the barred door). Encounter triggers when a hunter
+enters your room or you enter its room.
+
+## Pillar 4 — One column, one loop
+
+No combat screen, no clickable map. A single narrative column: room prose,
+sensory lines (exits with sensory tags, hunter audio), a slim status strip
+(HP, lamp, pack, alertness), choices inline.
+
+**Navigation** is prose exits: "North, a low arch — warm air, tallow smell."
+Direction words, not tiles. **The map is an item**: bought from the
+cartographer or found, weight 1; "Consult the map" (costs 1 oil, needs light)
+shows a non-interactive sketch of the place with your visited rooms marked.
+No map item, no sketch — you navigate on prose and memory.
+
+**Encounters** resolve inline in 1–3 **beats**. On contact: appraisal prose +
+decision set assembled from context — Fight / Slip past (vs. pack weight and
+light) / Fall back the way you came / context extras (parley, throw rations,
+lure). Each fight beat is a stance choice (Press / Guard / Break away) that
+resolves an aggregated exchange using the existing combat math (accuracy,
+evasion, armor, damage scaled ~2.5× per beat so fights end in 1–3 beats),
+burns oil, and emits noise. Talents and gear modify the decision set, not a
+swing-level action bar.
+
+## Pillar 5 — The run inverts
+
+Getting out is a different game from getting in. Extracts have conditions
+(above); at Hunting alertness a reinforcement pack spawns near the entrance;
+the water-clock keeps ticking. Death cost, insurance, and the pack ritual all
+stay exactly as shipped in v0.4.
+
+## Engine shape
+
+New pure modules under `src/game/delve/` (seeded rng, no React, heavily
+tested — same standards as the rest of `src/game/`):
+
+- `types.ts` — shared contracts (committed first; workers build against it)
+- `lamp.ts` — oil track, light states, costs
+- `noise.ts` — loudness propagation over the room graph
+- `hunters.ts` — spawn, state machine, tick, player-audible signals
+- `places/goblinWarrens.ts` + `place.ts` — authored-place format, loader,
+  validation, per-run population (loot, locks, hunter spawns)
+- `encounters.ts` — decision-set assembly + beat resolution over existing
+  combat math
+- `delveRun.ts` — the run state machine tying it together
+- UI: one new `DelveScreen` replacing DungeonScreen+CombatScreen when a
+  delve run is active; old screens stay until parity, then retire.
+
+Cutover: new-game runs use the delve engine behind a flag; old saves keep the
+old engine until we remove it. Balance targets: a competent first run should
+extract with ~60% pack and dim light; greed past that should feel the floor
+tilt.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { CharacterCreationScreen } from "./screens/CharacterCreationScreen";
 import { VillageScreen } from "./screens/VillageScreen";
 import { DungeonScreen } from "./screens/DungeonScreen";
 import { CombatScreen } from "./screens/CombatScreen";
+import { DelveScreen } from "./screens/DelveScreen";
 import { RunSummaryScreen } from "./screens/RunSummaryScreen";
 import { StashScreen } from "./screens/StashScreen";
 import { MerchantScreen } from "./screens/MerchantScreen";
@@ -38,6 +39,7 @@ export default function App() {
       {screen === "village" && <VillageScreen />}
       {screen === "dungeon" && <DungeonScreen />}
       {screen === "combat" && <CombatScreen />}
+      {screen === "delve" && <DelveScreen />}
       {screen === "runSummary" && <RunSummaryScreen />}
       {screen === "stash" && <StashScreen />}
       {screen === "character" && <CharacterScreen />}

--- a/src/components/DevPanel.tsx
+++ b/src/components/DevPanel.tsx
@@ -15,6 +15,7 @@ export function DevPanel() {
   const debugKillPlayer = useGameStore(s => s.debugKillPlayer);
   const debugForceExtraction = useGameStore(s => s.debugForceExtraction);
   const debugCompleteQuest = useGameStore(s => s.debugCompleteQuest);
+  const startDelveRun = useGameStore(s => s.startDelveRun);
 
   const metrics = useMemo(() => calculateRunMetrics(state.runSummaries), [state.runSummaries]);
   const saveJson = useMemo(() => JSON.stringify(state, null, 2), [state]);
@@ -47,6 +48,13 @@ export function DevPanel() {
           <Button variant="danger" onClick={debugKillPlayer} disabled={!state.activeRun}>Kill Player</Button>
           <Button variant="danger" onClick={debugForceExtraction} disabled={!state.activeRun}>Force Extract</Button>
           <Button variant="secondary" onClick={debugCompleteQuest} disabled={!state.village}>Complete Quest</Button>
+          <Button
+            variant="secondary"
+            onClick={() => startDelveRun("goblinWarrens")}
+            disabled={!state.player || Boolean(state.delveRun)}
+          >
+            Start Delve (Warrens)
+          </Button>
           <Button variant="ghost" onClick={() => setShowJson(value => !value)}>Save JSON</Button>
         </div>
 

--- a/src/game/ambient.ts
+++ b/src/game/ambient.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { getAudioContext, isAudioMuted } from "./audio";
 import { useGameStore } from "../store/gameStore";
 import type { ScreenId, ThreatLevel } from "./types";
+import { getThreatLevelFromPoints } from "./threat";
 
 // ---------------------------------------------------------------------------
 // Pure threat -> sound mapping (unit tested in src/tests/ambient.test.ts)
@@ -191,7 +192,7 @@ export class AmbientEngine {
   }
 
   private desiredBed(): AmbientBed {
-    if (this.screen === "dungeon" || this.screen === "combat") return "dungeon";
+    if (this.screen === "dungeon" || this.screen === "combat" || this.screen === "delve") return "dungeon";
     if (this.screen === "village") return "village";
     return "none";
   }
@@ -523,6 +524,11 @@ function isInCombat(screen: ScreenId, hasActiveCombat: boolean): boolean {
   return screen === "combat" || hasActiveCombat;
 }
 
+function delveThreatLevel(alertnessPoints: number | undefined): ThreatLevel {
+  if (alertnessPoints === undefined) return 0;
+  return getThreatLevelFromPoints(alertnessPoints);
+}
+
 /**
  * Mounts the ambient engine for the lifetime of the app. Reads screen and
  * threat state from the store, resumes the shared AudioContext on the first
@@ -533,8 +539,12 @@ export function useAmbientAudio(): void {
   if (!engineRef.current) engineRef.current = new AmbientEngine();
 
   const screen = useGameStore(s => s.screen);
-  const threatLevel = useGameStore(s => s.state.activeRun?.threat.level ?? 0);
-  const hasActiveCombat = useGameStore(s => Boolean(s.state.activeCombat && !s.state.activeCombat.over));
+  const threatLevel = useGameStore(s =>
+    s.state.activeRun?.threat.level ?? delveThreatLevel(s.state.delveRun?.alertness)
+  );
+  const hasActiveCombat = useGameStore(s =>
+    Boolean(s.state.activeCombat && !s.state.activeCombat.over) || Boolean(s.state.delveRun?.activeEncounter)
+  );
   const muted = useGameStore(s => s.state.settings.audioMuted);
 
   useEffect(() => {

--- a/src/game/combat.ts
+++ b/src/game/combat.ts
@@ -245,7 +245,7 @@ function findInInventoryAndEquipped(
   return equippedItems.find(i => i.instanceId === instanceId);
 }
 
-function guessWeaponDice(weapon: ItemInstance): { count: number; sides: number } {
+export function guessWeaponDice(weapon: ItemInstance): { count: number; sides: number } {
   if (weapon.tags?.includes("two-handed")) return { count: 1, sides: 10 };
   if (weapon.tags?.includes("blade")) return { count: 1, sides: 8 };
   if (weapon.tags?.includes("blunt")) return { count: 1, sides: 8 };
@@ -255,7 +255,7 @@ function guessWeaponDice(weapon: ItemInstance): { count: number; sides: number }
   return { count: 1, sides: 6 };
 }
 
-function getDamageBonus(player: Character, weapon?: ItemInstance): number {
+export function getDamageBonus(player: Character, weapon?: ItemInstance): number {
   if (weapon?.tags?.includes("magic")) {
     return Math.max(0, player.derivedStats.magicPower);
   }

--- a/src/game/delve/delveRun.ts
+++ b/src/game/delve/delveRun.ts
@@ -241,10 +241,15 @@ const SENSE_TEXT: Record<SenseTag, string> = {
   narrowSqueeze: "a narrow squeeze"
 };
 
+const DIRECTION_PHRASE: Record<string, string> = {
+  north: "To the north", east: "To the east", south: "To the south", west: "To the west",
+  up: "Above", down: "Below"
+};
+
 function exitLine(state: DelveRunState, roomId: string, exit: PlaceExit): string {
   const senses = (exit.senses ?? []).map(s => SENSE_TEXT[s]).join(", ");
   const doorState = state.doorOverrides[`${roomId}:${exit.direction}`];
-  let line = `To the ${exit.direction}, a way on`;
+  let line = `${DIRECTION_PHRASE[exit.direction] ?? `To the ${exit.direction}`}, a way on`;
   if (senses) line += ` — ${senses}`;
   if (doorState === "locked") line += ". The door there is locked fast";
   else if (doorState === "jammed") line += ". The door there is jammed in its frame";
@@ -294,7 +299,11 @@ function signalLine(signal: HunterSignal): string {
   if (signal.distance === 0) return "It is here, in the room with you.";
   const where = signal.direction === "near"
     ? "close by"
-    : `to the ${signal.direction}`;
+    : signal.direction === "up"
+      ? "overhead"
+      : signal.direction === "down"
+        ? "beneath you"
+        : `to the ${signal.direction}`;
   const range = signal.distance === 1 ? "close" : "farther off";
   return `Something ${signal.texture} ${where}, ${range}.`;
 }

--- a/src/game/delve/delveRun.ts
+++ b/src/game/delve/delveRun.ts
@@ -1,0 +1,1125 @@
+// The delve run state machine (Pillar 5) — the keystone tying lamp, noise,
+// hunters, place, and encounters into one pure reducer. No React, no Zustand;
+// the store slice composes this later. See docs/design/the-delve.md.
+//
+// Shape: createDelveRun(params) builds the initial DelveRunState;
+// applyDelveAction(state, action, deps) is the single reducer-style entry
+// point. Character stats/hp/inventory stay OUTSIDE this state — the engine
+// reads a snapshot from deps and reports hp/inventory changes as events for
+// the store to apply, which keeps it pure and directly testable.
+
+import type {
+  DelveAction,
+  DelveActionResult,
+  DelveNarrativeEntry,
+  DelveRunDeps,
+  DelveRunEvent,
+  DelveRunState,
+  DelveSupplyCache,
+  Direction,
+  EncounterOptionKind,
+  Hunter,
+  HunterSignal,
+  NoiseEvent,
+  PlaceExit,
+  PlaceExtract,
+  PlaceFloor,
+  PlaceRoom,
+  SenseTag
+} from "./types";
+import type { ItemInstance } from "../types";
+import { createRng, makeId, type Rng } from "../rng";
+import { getLightState, refillFromFlask, spendOil } from "./lamp";
+import {
+  bfsPath,
+  emitNoise,
+  graphDistance,
+  moveNoiseLoudness,
+  NOISE_LOUDNESS,
+  type RoomAdjacency
+} from "./noise";
+import { tickHunters } from "./hunters";
+import { buildAdjacency, getPlace, populateFloor } from "./place";
+import { openEncounter, resolveFightBeat, resolveOption } from "./encounters";
+import { getThreatLevelFromPoints } from "../threat";
+import { DEPTH_RULES } from "../constants";
+import { generateLootForRoomLootTableId, rollGold } from "../lootGenerator";
+import { ENEMIES } from "../../data/enemies";
+
+// ---------------------------------------------------------------------------
+// Tuning constants (documented judgment calls)
+// ---------------------------------------------------------------------------
+
+/** Default global run timer: actions until the flooded stair closes. */
+export const DEFAULT_WATER_CLOCK = 45;
+
+/** Chance that one lockwork attempt opens a locked/jammed door. */
+const LOCKWORK_SUCCESS_CHANCE = 0.65;
+
+/** Chance a defeated hunter drops loot into the room's pending pool. */
+const HUNTER_LOOT_DROP_CHANCE = 0.5;
+
+/** Alertness level (THREAT_RULES "Hunting") that spawns a reinforcement. */
+const REINFORCEMENT_ALERTNESS_LEVEL = 3;
+
+/** How far "listen" reaches, vs. the passive 2-room hunter signals. */
+const LISTEN_DISTANCE = 3;
+
+// ---------------------------------------------------------------------------
+// createDelveRun
+// ---------------------------------------------------------------------------
+
+export interface CreateDelveRunParams {
+  placeId: string;
+  seed: string;
+  tier?: number;
+  hasMapItem?: boolean;
+  flasksPacked?: number;
+  lampCapacity?: number;
+  waterClock?: number;
+}
+
+export function createDelveRun(params: CreateDelveRunParams): DelveRunState {
+  const {
+    placeId,
+    seed,
+    tier = 1,
+    hasMapItem = false,
+    flasksPacked = 1,
+    lampCapacity = 20,
+    waterClock = DEFAULT_WATER_CLOCK
+  } = params;
+
+  const place = getPlace(placeId);
+  const floor = floorData(place.id, 1);
+  const rng = createRng(`${seed}:populate:1`);
+  const populated = populateFloor({ floor, rng, tier });
+
+  const hunters = spawnFloorHunters(floor, populated.hunterSpawnRoomIds, place.biome, tier, rng);
+
+  const state: DelveRunState = {
+    placeId,
+    floor: 1,
+    seed,
+    tier,
+    status: "active",
+    actionCount: 0,
+    currentRoomId: floor.entranceRoomId,
+    cameFromRoomId: undefined,
+    visitedRoomIds: [floor.entranceRoomId],
+    lamp: { oil: lampCapacity, capacity: lampCapacity, flasksPacked },
+    hunters,
+    alertness: 0,
+    waterClock,
+    cranksDone: {},
+    doorOverrides: populated.doorOverrides,
+    roomProse: populated.roomProse,
+    lootRoomIds: populated.lootRoomIds,
+    searchedRoomIds: [],
+    supplyCaches: populated.supplyRoomIds.map(s => ({ ...s, found: false })),
+    pendingLoot: {},
+    activeEncounter: undefined,
+    hasMapItem,
+    narrative: []
+  };
+
+  const ctx = makeCtx(state);
+  appendRoomProse(ctx, floor.entranceRoomId, true);
+  state.narrative = ctx.allNarrative;
+  return state;
+}
+
+function spawnFloorHunters(
+  floor: PlaceFloor,
+  spawnRoomIds: string[],
+  biome: string,
+  tier: number,
+  rng: Rng
+): Hunter[] {
+  const pool = enemyPoolFor(biome, tier, floor.floor);
+  // populateFloor already rolled the count and rooms; spin the hunters up
+  // directly so the budget roll isn't consumed twice.
+  return spawnRoomIds.map((roomId): Hunter => ({
+    id: makeId(rng, "hunter"),
+    enemyId: rng.pickOne(pool),
+    roomId,
+    state: "dormant"
+  }));
+}
+
+function enemyPoolFor(biome: string, tier: number, floor: number): string[] {
+  const cap = Math.max(1, tier + floor - 1);
+  const inTier = ENEMIES.filter(e => e.biome === biome && e.tier <= cap).map(e => e.id);
+  if (inTier.length > 0) return inTier;
+  const anyBiome = ENEMIES.filter(e => e.biome === biome).map(e => e.id);
+  if (anyBiome.length > 0) return anyBiome;
+  throw new Error(`No bestiary entries for biome "${biome}"`);
+}
+
+// ---------------------------------------------------------------------------
+// Working context: collects narrative/events while building the next state
+// ---------------------------------------------------------------------------
+
+interface Ctx {
+  state: DelveRunState; // a fresh mutable draft, never the caller's object
+  narrative: DelveNarrativeEntry[]; // entries appended by this action
+  allNarrative: DelveNarrativeEntry[];
+  events: DelveRunEvent[];
+  seq: number;
+}
+
+function makeCtx(state: DelveRunState): Ctx {
+  // Shallow-clone the layers this reducer mutates; nested payloads
+  // (ItemInstance, Hunter, narrative entries) are replaced, not mutated.
+  const draft: DelveRunState = {
+    ...state,
+    lamp: { ...state.lamp },
+    hunters: state.hunters.map(h => ({ ...h })),
+    visitedRoomIds: [...state.visitedRoomIds],
+    searchedRoomIds: [...state.searchedRoomIds],
+    supplyCaches: state.supplyCaches.map(s => ({ ...s })),
+    cranksDone: { ...state.cranksDone },
+    doorOverrides: { ...state.doorOverrides },
+    pendingLoot: Object.fromEntries(
+      Object.entries(state.pendingLoot).map(([k, v]) => [
+        k,
+        { items: [...v.items], gold: v.gold, materials: { ...v.materials } }
+      ])
+    ),
+    activeEncounter: state.activeEncounter
+      ? { ...state.activeEncounter, options: [...state.activeEncounter.options], log: [...state.activeEncounter.log] }
+      : undefined
+  };
+  return { state: draft, narrative: [], allNarrative: [...state.narrative], events: [], seq: 0 };
+}
+
+function say(ctx: Ctx, kind: DelveNarrativeEntry["kind"], text: string): void {
+  const entry: DelveNarrativeEntry = {
+    id: `n${ctx.state.actionCount}_${ctx.seq++}`,
+    kind,
+    text
+  };
+  ctx.narrative.push(entry);
+  ctx.allNarrative.push(entry);
+}
+
+function finish(ctx: Ctx): DelveActionResult {
+  ctx.state.narrative = ctx.allNarrative;
+  return { state: ctx.state, narrative: ctx.narrative, events: ctx.events };
+}
+
+// ---------------------------------------------------------------------------
+// Place helpers
+// ---------------------------------------------------------------------------
+
+function floorData(placeId: string, floor: number): PlaceFloor {
+  const data = getPlace(placeId).floors.find(f => f.floor === floor);
+  if (!data) throw new Error(`Place "${placeId}" has no floor ${floor}`);
+  return data;
+}
+
+function roomById(floor: PlaceFloor, roomId: string): PlaceRoom {
+  const room = floor.rooms.find(r => r.id === roomId);
+  if (!room) throw new Error(`Unknown room "${roomId}" on floor ${floor.floor}`);
+  return room;
+}
+
+function makeDirectionOf(floor: PlaceFloor): (from: string, to: string) => Direction | undefined {
+  return (from, to) => roomById(floor, from).exits.find(e => e.to === to)?.direction;
+}
+
+const SENSE_TEXT: Record<SenseTag, string> = {
+  tallow: "tallow smoke",
+  warmAir: "warm air",
+  coldDraft: "a cold draft",
+  waterSound: "the sound of water",
+  greaseSmell: "the smell of old grease",
+  rotSmell: "the smell of rot",
+  silence: "a dead silence",
+  chittering: "faint chittering",
+  lightBeyond: "a hint of light beyond",
+  narrowSqueeze: "a narrow squeeze"
+};
+
+function exitLine(state: DelveRunState, roomId: string, exit: PlaceExit): string {
+  const senses = (exit.senses ?? []).map(s => SENSE_TEXT[s]).join(", ");
+  const doorState = state.doorOverrides[`${roomId}:${exit.direction}`];
+  let line = `To the ${exit.direction}, a way on`;
+  if (senses) line += ` — ${senses}`;
+  if (doorState === "locked") line += ". The door there is locked fast";
+  else if (doorState === "jammed") line += ". The door there is jammed in its frame";
+  else if (doorState === "shut") line += ". The door there is shut";
+  return `${line}.`;
+}
+
+function appendRoomProse(ctx: Ctx, roomId: string, firstVisit: boolean): void {
+  const floor = floorData(ctx.state.placeId, ctx.state.floor);
+  const room = roomById(floor, roomId);
+  if (firstVisit) {
+    say(ctx, "room", `${room.name}. ${ctx.state.roomProse[roomId] ?? room.prose[0]}`);
+  } else {
+    say(ctx, "room", `${room.name}, again.`);
+  }
+  for (const exit of room.exits) {
+    say(ctx, "sense", exitLine(ctx.state, roomId, exit));
+  }
+  const pool = ctx.state.pendingLoot[roomId];
+  if (pool && (pool.items.length > 0 || pool.gold > 0)) {
+    say(ctx, "sense", "What you left ungathered still lies here.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Alertness, water clock, hunter tick — the shared per-action simulation step
+// ---------------------------------------------------------------------------
+
+const ESCALATION_LINES: Record<number, string> = {
+  1: "Something is listening now.",
+  2: "The halls begin to stir.",
+  3: "Footsteps you don't own, drawing closer.",
+  4: "You are being hunted.",
+  5: "The dungeon wakes fully."
+};
+
+function hunterTexture(state: Hunter["state"]): string {
+  switch (state) {
+    case "hunting": return "closing in";
+    case "drawn": return "moving toward you";
+    case "roaming": return "shuffling about";
+    case "dormant": return "still";
+  }
+}
+
+function signalLine(signal: HunterSignal): string {
+  if (signal.distance === 0) return "It is here, in the room with you.";
+  const where = signal.direction === "near"
+    ? "close by"
+    : `to the ${signal.direction}`;
+  const range = signal.distance === 1 ? "close" : "farther off";
+  return `Something ${signal.texture} ${where}, ${range}.`;
+}
+
+/**
+ * The cross-cutting per-action step: alertness rises by the loudness emitted,
+ * escalation lines land at threshold crossings (with a reinforcement hunter
+ * at Hunting), the water clock ticks down, and the hunter simulation runs.
+ * Contact opens an encounter unless one is already active.
+ * `excludeHunterId` skips one hunter this tick (it was just evaded/engaged).
+ */
+function applySimTick(
+  ctx: Ctx,
+  deps: DelveRunDeps,
+  rng: Rng,
+  noises: NoiseEvent[],
+  excludeHunterId?: string
+): void {
+  const state = ctx.state;
+  const floor = floorData(state.placeId, state.floor);
+  const adjacency = buildAdjacency(floor);
+
+  // Alertness only rises; points equal the loudness emitted this action.
+  const emitted = noises.map(n => emitNoise(n));
+  const gained = emitted.reduce((sum, n) => sum + n.loudness, 0);
+  const previousLevel = getThreatLevelFromPoints(state.alertness);
+  state.alertness += gained;
+  const newLevel = getThreatLevelFromPoints(state.alertness);
+
+  for (let level = previousLevel + 1; level <= newLevel; level++) {
+    const line = ESCALATION_LINES[level];
+    if (line) say(ctx, "system", line);
+    ctx.events.push({ kind: "alertnessLevel", level });
+    if (level === REINFORCEMENT_ALERTNESS_LEVEL) {
+      spawnReinforcement(ctx, floor, adjacency, rng);
+    }
+  }
+
+  // The water clock is a global, actions-based timer.
+  if (state.waterClock > 0) {
+    state.waterClock -= 1;
+    if (state.waterClock === 0) {
+      say(ctx, "system", "Somewhere below, water swallows stone. The flooded stair is drowning.");
+    }
+  }
+
+  // Hunter simulation.
+  const ticking = state.hunters.filter(h => h.id !== excludeHunterId);
+  const held = state.hunters.filter(h => h.id === excludeHunterId);
+  const result = tickHunters({
+    hunters: ticking,
+    adjacency,
+    playerRoomId: state.currentRoomId,
+    noises: emitted,
+    alertnessLevel: newLevel,
+    rng,
+    directionOf: makeDirectionOf(floor)
+  });
+  state.hunters = [...result.hunters, ...held];
+
+  if (!state.activeEncounter) {
+    for (const signal of result.signals) {
+      if (signal.distance === 0) continue; // contact handles distance 0
+      say(ctx, "sense", signalLine(signal));
+    }
+    const contactId = result.contacts[0];
+    if (contactId) {
+      beginEncounter(ctx, deps, rng, contactId);
+    }
+  }
+}
+
+function spawnReinforcement(ctx: Ctx, floor: PlaceFloor, adjacency: RoomAdjacency, rng: Rng): void {
+  const state = ctx.state;
+  const place = getPlace(state.placeId);
+  const nearEntrance = [floor.entranceRoomId, ...(adjacency[floor.entranceRoomId] ?? [])];
+  const candidates = nearEntrance.filter(id => id !== state.currentRoomId);
+  const roomId = rng.pickOne(candidates.length > 0 ? candidates : nearEntrance);
+  const hunter: Hunter = {
+    id: makeId(rng, "hunter"),
+    enemyId: rng.pickOne(enemyPoolFor(place.biome, state.tier, state.floor)),
+    roomId,
+    state: "roaming"
+  };
+  state.hunters = [...state.hunters, hunter];
+  say(ctx, "system", "From back toward the entrance: new voices, and they are not lost.");
+  ctx.events.push({ kind: "reinforcement", hunterId: hunter.id, roomId });
+}
+
+// ---------------------------------------------------------------------------
+// Encounter plumbing
+// ---------------------------------------------------------------------------
+
+function beginEncounter(ctx: Ctx, deps: DelveRunDeps, rng: Rng, hunterId: string): void {
+  const state = ctx.state;
+  const hunter = state.hunters.find(h => h.id === hunterId);
+  if (!hunter) return;
+  const floor = floorData(state.placeId, state.floor);
+  const adjacency = buildAdjacency(floor);
+  const encounter = openEncounter({
+    hunter,
+    character: deps.character,
+    carriedItems: deps.carriedItems,
+    lightState: getLightState(state.lamp),
+    packRatio: packRatio(deps),
+    cameFromRoomId: state.cameFromRoomId,
+    alertnessLevel: getThreatLevelFromPoints(state.alertness),
+    adjacentRoomIds: adjacency[state.currentRoomId] ?? [],
+    rng: rng.forkChild(`open:${hunterId}`)
+  });
+  state.activeEncounter = encounter;
+  for (const line of encounter.log) {
+    say(ctx, "encounter", line);
+  }
+}
+
+function packRatio(deps: DelveRunDeps): number {
+  if (deps.carryCapacity <= 0) return 1;
+  return deps.carriedWeight / deps.carryCapacity;
+}
+
+/** Shove an evaded hunter into an adjacent room; it lost track of you. */
+function displaceHunter(ctx: Ctx, hunterId: string, rng: Rng): void {
+  const state = ctx.state;
+  const floor = floorData(state.placeId, state.floor);
+  const adjacency = buildAdjacency(floor);
+  state.hunters = state.hunters.map(h => {
+    if (h.id !== hunterId) return h;
+    const neighbors = adjacency[h.roomId] ?? [];
+    const roomId = neighbors.length > 0 ? rng.pickOne(neighbors) : h.roomId;
+    return { ...h, roomId, state: "roaming", heardAt: undefined };
+  });
+}
+
+function movePlayer(ctx: Ctx, toRoomId: string): void {
+  const state = ctx.state;
+  state.cameFromRoomId = state.currentRoomId;
+  state.currentRoomId = toRoomId;
+  const firstVisit = !state.visitedRoomIds.includes(toRoomId);
+  if (firstVisit) state.visitedRoomIds = [...state.visitedRoomIds, toRoomId];
+  appendRoomProse(ctx, toRoomId, firstVisit);
+}
+
+function dropHunterLoot(ctx: Ctx, roomId: string, rng: Rng): void {
+  const state = ctx.state;
+  if (rng.nextFloat() >= HUNTER_LOOT_DROP_CHANCE) return;
+  const floor = floorData(state.placeId, state.floor);
+  const room = roomById(floor, roomId);
+  const place = getPlace(state.placeId);
+  const tableId = room.lootTableId ?? `loot_${place.biome === "goblinWarrens" ? "goblin" : place.biome}_t1`;
+  let items: ItemInstance[] = [];
+  try {
+    items = generateLootForRoomLootTableId(tableId, rng.forkChild("drop"), 1, {
+      tier: state.tier,
+      source: "combat"
+    });
+  } catch {
+    return; // no matching table for this biome — no drop
+  }
+  const gold = rollGold(rng, state.tier);
+  addToPendingLoot(state, roomId, items, gold);
+  say(ctx, "action", "It was carrying something worth stooping for.");
+  ctx.events.push({ kind: "lootFound", roomId });
+}
+
+function addToPendingLoot(state: DelveRunState, roomId: string, items: ItemInstance[], gold: number): void {
+  const existing = state.pendingLoot[roomId] ?? { items: [], gold: 0, materials: {} };
+  state.pendingLoot = {
+    ...state.pendingLoot,
+    [roomId]: {
+      items: [...existing.items, ...items],
+      gold: existing.gold + gold,
+      materials: existing.materials
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// applyDelveAction
+// ---------------------------------------------------------------------------
+
+export function applyDelveAction(
+  state: DelveRunState,
+  action: DelveAction,
+  deps: DelveRunDeps
+): DelveActionResult {
+  const ctx = makeCtx(state);
+  ctx.state.actionCount += 1;
+  ctx.seq = 0;
+  const rng = createRng(`${state.seed}:action:${ctx.state.actionCount}:${action.type}`);
+
+  if (ctx.state.status !== "active") {
+    say(ctx, "system", ctx.state.status === "dead"
+      ? "The run is over. The Warrens keep what they took."
+      : "You are already out, under open sky.");
+    return finish(ctx);
+  }
+
+  if (ctx.state.activeEncounter && action.type !== "encounterOption" && action.type !== "fightBeat") {
+    say(ctx, "encounter", "It is between you and everything else. Deal with it first.");
+    return finish(ctx);
+  }
+
+  switch (action.type) {
+    case "move": return doMove(ctx, deps, rng, action.direction);
+    case "search": return doSearch(ctx, deps, rng);
+    case "listen": return doListen(ctx, deps, rng);
+    case "takeLoot": return doTakeLoot(ctx, deps, action.itemInstanceId);
+    case "takeAllLoot": return doTakeAllLoot(ctx, deps);
+    case "leaveLoot": return doLeaveLoot(ctx);
+    case "refillLamp": return doRefillLamp(ctx);
+    case "consultMap": return doConsultMap(ctx);
+    case "encounterOption": return doEncounterOption(ctx, deps, rng, action.kind);
+    case "fightBeat": return doFightBeat(ctx, deps, rng, action.stance);
+    case "crank": return doCrank(ctx, deps, rng, action.extractId);
+    case "extract": return doExtract(ctx, action.extractId);
+    case "descend": return doDescend(ctx, action.stairRoomId);
+  }
+}
+
+// --- move --------------------------------------------------------------
+
+function doMove(ctx: Ctx, deps: DelveRunDeps, rng: Rng, direction: Direction): DelveActionResult {
+  const state = ctx.state;
+  const floor = floorData(state.placeId, state.floor);
+  const room = roomById(floor, state.currentRoomId);
+  const exit = room.exits.find(e => e.direction === direction);
+
+  if (!exit) {
+    say(ctx, "system", `There is no way ${direction} from here.`);
+    return finish(ctx);
+  }
+
+  const lightState = getLightState(state.lamp);
+  const overrideKey = `${state.currentRoomId}:${direction}`;
+  const doorState = state.doorOverrides[overrideKey];
+
+  if (doorState === "locked" || doorState === "jammed") {
+    // Lockwork: oil 2 ("disarm" on the oil track), noise 3, may fail.
+    state.lamp = spendOil(state.lamp, "disarm");
+    const noise: NoiseEvent = { roomId: state.currentRoomId, loudness: NOISE_LOUDNESS.lockwork, cause: "lockwork" };
+    const succeeded = rng.nextFloat() < LOCKWORK_SUCCESS_CHANCE;
+    if (succeeded) {
+      delete state.doorOverrides[overrideKey];
+      say(ctx, "action", doorState === "locked"
+        ? "The lock gives with a grind of cheap iron, louder than you'd like."
+        : "You lever the door out of its frame. The wood screams about it.");
+      movePlayer(ctx, exit.to);
+    } else {
+      say(ctx, "action", doorState === "locked"
+        ? "The pick slips. The lock rattles its complaint down the passage."
+        : "The door doesn't budge, and the whole frame booms with the effort.");
+    }
+    applySimTick(ctx, deps, rng, [noise]);
+    return finish(ctx);
+  }
+
+  if (doorState === "shut") {
+    delete state.doorOverrides[overrideKey];
+    say(ctx, "action", "You ease the door open.");
+  }
+
+  state.lamp = spendOil(state.lamp, "move");
+  const noise: NoiseEvent = {
+    roomId: exit.to,
+    loudness: moveNoiseLoudness({ packRatio: packRatio(deps), lightState }),
+    cause: "move"
+  };
+  movePlayer(ctx, exit.to);
+  applySimTick(ctx, deps, rng, [noise]);
+  return finish(ctx);
+}
+
+// --- search ------------------------------------------------------------
+
+function doSearch(ctx: Ctx, deps: DelveRunDeps, rng: Rng): DelveActionResult {
+  const state = ctx.state;
+  const lightState = getLightState(state.lamp);
+
+  if (lightState === "dark") {
+    say(ctx, "system", "You can't search what you can't see. The dark gives nothing up.");
+    return finish(ctx);
+  }
+
+  state.lamp = spendOil(state.lamp, "search");
+  const roomId = state.currentRoomId;
+  const noise: NoiseEvent = { roomId, loudness: NOISE_LOUDNESS.search, cause: "search" };
+
+  if (state.searchedRoomIds.includes(roomId)) {
+    say(ctx, "action", "You have already turned this room over. Nothing new.");
+    applySimTick(ctx, deps, rng, [noise]);
+    return finish(ctx);
+  }
+  state.searchedRoomIds = [...state.searchedRoomIds, roomId];
+
+  let foundAnything = false;
+
+  // Marked loot rooms roll from the existing loot system into the pending pool.
+  if (state.lootRoomIds.includes(roomId)) {
+    const floor = floorData(state.placeId, state.floor);
+    const room = roomById(floor, roomId);
+    if (room.lootTableId) {
+      // Dim light: search yields worse (fewer items, less coin).
+      const itemCount = lightState === "dim" ? 1 : rng.nextInt(1, 2);
+      const items = generateLootForRoomLootTableId(room.lootTableId, rng.forkChild("loot"), itemCount, {
+        tier: state.tier,
+        source: "treasure"
+      });
+      let gold = rollGold(rng, state.tier);
+      if (lightState === "dim") gold = Math.floor(gold / 2);
+      addToPendingLoot(state, roomId, items, gold);
+      say(ctx, "action", lightState === "dim"
+        ? "In the guttering light you find some of what's hidden here — surely not all of it."
+        : "Your hands find what the Warrens squirreled away here.");
+      ctx.events.push({ kind: "lootFound", roomId });
+      foundAnything = true;
+    }
+  }
+
+  // Supply caches yield oil flasks / rations as items.
+  const cache = state.supplyCaches.find(s => s.roomId === roomId && !s.found);
+  if (cache) {
+    cache.found = true;
+    const item = cache.kind === "oilFlask" ? makeOilFlaskItem(rng) : makeRationsItem(rng);
+    addToPendingLoot(state, roomId, [item], 0);
+    say(ctx, "action", cache.kind === "oilFlask"
+      ? "Tucked behind a loose brace: a stoppered flask of lamp oil."
+      : "A bundle of rations, wrapped and forgotten.");
+    ctx.events.push({ kind: "lootFound", roomId });
+    foundAnything = true;
+  }
+
+  if (!foundAnything) {
+    say(ctx, "action", "You turn the room over and come up with nothing but grime.");
+  }
+
+  applySimTick(ctx, deps, rng, [noise]);
+  return finish(ctx);
+}
+
+function makeOilFlaskItem(rng: Rng): ItemInstance {
+  return {
+    instanceId: makeId(rng, "item"),
+    templateId: "delve_oil_flask",
+    name: "Oil Flask",
+    category: "consumable",
+    rarity: "common",
+    description: "A stoppered flask of lamp oil. A full refill.",
+    value: 10,
+    weight: 2,
+    stackable: true,
+    quantity: 1,
+    tags: ["oilFlask", "oil"],
+    affixes: [],
+    states: []
+  };
+}
+
+function makeRationsItem(rng: Rng): ItemInstance {
+  return {
+    instanceId: makeId(rng, "item"),
+    templateId: "consumable_trail_ration",
+    name: "Trail Ration",
+    category: "consumable",
+    rarity: "common",
+    description: "Hard bread, dried meat, a little salt.",
+    value: 2,
+    weight: 1,
+    stackable: true,
+    quantity: 1,
+    tags: ["food", "ration"],
+    affixes: [],
+    states: []
+  };
+}
+
+// --- listen ------------------------------------------------------------
+
+function doListen(ctx: Ctx, deps: DelveRunDeps, rng: Rng): DelveActionResult {
+  const state = ctx.state;
+  state.lamp = spendOil(state.lamp, "listen");
+  say(ctx, "action", "You still your breathing and listen.");
+
+  // No noise emitted: listening is the one quiet way to spend time.
+  applySimTick(ctx, deps, rng, []);
+  if (state.activeEncounter) return finish(ctx); // contact interrupted the listen
+
+  const floor = floorData(state.placeId, state.floor);
+  const adjacency = buildAdjacency(floor);
+  const directionOf = makeDirectionOf(floor);
+  let heardAny = false;
+  for (const hunter of state.hunters) {
+    const distance = graphDistance(adjacency, state.currentRoomId, hunter.roomId);
+    if (distance === undefined || distance === 0 || distance > LISTEN_DISTANCE) continue;
+    const path = bfsPath(adjacency, state.currentRoomId, hunter.roomId);
+    const firstStep = path && path.length > 1 ? path[1] : undefined;
+    const direction = firstStep ? directionOf(state.currentRoomId, firstStep) : undefined;
+    const where = direction ? `to the ${direction}` : "close by";
+    const range = distance === 1 ? "one room off" : `${distance} rooms off`;
+    say(ctx, "sense", `Something ${hunterTexture(hunter.state)} ${where}, ${range}.`);
+    heardAny = true;
+  }
+  if (!heardAny) {
+    say(ctx, "sense", "Nothing but your own blood in your ears.");
+  }
+  return finish(ctx);
+}
+
+// --- loot (quiet, quick: no oil, no noise, no tick) ---------------------
+
+function doTakeLoot(ctx: Ctx, deps: DelveRunDeps, itemInstanceId?: string): DelveActionResult {
+  const state = ctx.state;
+  const roomId = state.currentRoomId;
+  const pool = state.pendingLoot[roomId];
+  if (!pool) {
+    say(ctx, "system", "Nothing here to take.");
+    return finish(ctx);
+  }
+
+  if (!itemInstanceId) {
+    // Bare takeLoot sweeps the weightless part of the pool: coin and materials.
+    if (pool.gold <= 0 && Object.keys(pool.materials).length === 0) {
+      say(ctx, "system", "No coin here — name what you want to carry.");
+      return finish(ctx);
+    }
+    const gold = pool.gold;
+    const materials = pool.materials;
+    updatePool(state, roomId, { ...pool, gold: 0, materials: {} });
+    say(ctx, "action", gold > 0 ? `You pocket ${gold} gold.` : "You pocket what's worth pocketing.");
+    ctx.events.push({ kind: "itemsTaken", roomId, items: [], gold, materials });
+    return finish(ctx);
+  }
+
+  const item = pool.items.find(i => i.instanceId === itemInstanceId);
+  if (!item) {
+    say(ctx, "system", "That isn't here.");
+    return finish(ctx);
+  }
+  if (deps.carriedWeight + item.weight * item.quantity > deps.carryCapacity) {
+    say(ctx, "system", `The ${item.name} won't fit. Your pack is already straining.`);
+    return finish(ctx);
+  }
+  takeItems(ctx, roomId, [item], 0, {});
+  return finish(ctx);
+}
+
+function doTakeAllLoot(ctx: Ctx, deps: DelveRunDeps): DelveActionResult {
+  const state = ctx.state;
+  const roomId = state.currentRoomId;
+  const pool = state.pendingLoot[roomId];
+  if (!pool || (pool.items.length === 0 && pool.gold <= 0 && Object.keys(pool.materials).length === 0)) {
+    say(ctx, "system", "Nothing here to take.");
+    return finish(ctx);
+  }
+
+  const taken: ItemInstance[] = [];
+  let weight = deps.carriedWeight;
+  for (const item of pool.items) {
+    const itemWeight = item.weight * item.quantity;
+    if (weight + itemWeight <= deps.carryCapacity) {
+      taken.push(item);
+      weight += itemWeight;
+    }
+  }
+  const leftBehind = pool.items.length - taken.length;
+  takeItems(ctx, roomId, taken, pool.gold, pool.materials);
+  if (leftBehind > 0) {
+    say(ctx, "system", `Your pack can't hold everything. ${leftBehind} thing${leftBehind > 1 ? "s" : ""} stay behind.`);
+  }
+  return finish(ctx);
+}
+
+function takeItems(
+  ctx: Ctx,
+  roomId: string,
+  items: ItemInstance[],
+  gold: number,
+  materials: Record<string, number>
+): void {
+  const state = ctx.state;
+  const pool = state.pendingLoot[roomId]!;
+  const takenIds = new Set(items.map(i => i.instanceId));
+  updatePool(state, roomId, {
+    items: pool.items.filter(i => !takenIds.has(i.instanceId)),
+    gold: pool.gold - gold,
+    // Materials are taken all-or-nothing (they're weightless dust and scrap).
+    materials: Object.keys(materials).length > 0 ? {} : pool.materials
+  });
+
+  // Bagging an oil flask also stocks the lamp's refill count; the item event
+  // still fires so the store can account for pack weight.
+  const flasks = items.filter(i => i.tags?.includes("oilFlask")).reduce((n, i) => n + i.quantity, 0);
+  if (flasks > 0) {
+    state.lamp = { ...state.lamp, flasksPacked: state.lamp.flasksPacked + flasks };
+  }
+
+  const names = items.map(i => (i.quantity > 1 ? `${i.name} x${i.quantity}` : i.name));
+  const parts = [...names];
+  if (gold > 0) parts.push(`${gold} gold`);
+  say(ctx, "action", parts.length > 0 ? `Into the pack: ${parts.join(", ")}.` : "You take what's here.");
+  ctx.events.push({ kind: "itemsTaken", roomId, items, gold, materials });
+}
+
+function updatePool(
+  state: DelveRunState,
+  roomId: string,
+  pool: { items: ItemInstance[]; gold: number; materials: Record<string, number> }
+): void {
+  if (pool.items.length === 0 && pool.gold <= 0 && Object.keys(pool.materials).length === 0) {
+    const next = { ...state.pendingLoot };
+    delete next[roomId];
+    state.pendingLoot = next;
+  } else {
+    state.pendingLoot = { ...state.pendingLoot, [roomId]: pool };
+  }
+}
+
+function doLeaveLoot(ctx: Ctx): DelveActionResult {
+  const state = ctx.state;
+  const roomId = state.currentRoomId;
+  if (!state.pendingLoot[roomId]) {
+    say(ctx, "system", "Nothing here to leave.");
+    return finish(ctx);
+  }
+  const next = { ...state.pendingLoot };
+  delete next[roomId];
+  state.pendingLoot = next;
+  say(ctx, "action", "You leave it where it lies. Weight is its own kind of noise.");
+  return finish(ctx);
+}
+
+// --- lamp --------------------------------------------------------------
+
+function doRefillLamp(ctx: Ctx): DelveActionResult {
+  const state = ctx.state;
+  if (state.lamp.flasksPacked <= 0) {
+    say(ctx, "system", "You pat the pack down twice. No oil left to pour.");
+    return finish(ctx);
+  }
+  state.lamp = refillFromFlask(state.lamp);
+  say(ctx, "action", "You feed the lamp from a flask. The light steadies and spreads.");
+  ctx.events.push({ kind: "flaskConsumed" });
+  return finish(ctx);
+}
+
+// --- map ---------------------------------------------------------------
+
+function doConsultMap(ctx: Ctx): DelveActionResult {
+  const state = ctx.state;
+  if (!state.hasMapItem) {
+    say(ctx, "system", "You carry no map of this place. Prose and memory will have to serve.");
+    return finish(ctx);
+  }
+  if (getLightState(state.lamp) === "dark") {
+    say(ctx, "system", "There is no light to read by. The sketch stays a rumor in your pocket.");
+    return finish(ctx);
+  }
+  state.lamp = spendOil(state.lamp, "consultMap");
+  say(ctx, "map", "You unfold the cartographer's sketch and mark where you've been.");
+  return finish(ctx);
+}
+
+// --- encounters ----------------------------------------------------------
+
+function doEncounterOption(
+  ctx: Ctx,
+  deps: DelveRunDeps,
+  rng: Rng,
+  kind: EncounterOptionKind
+): DelveActionResult {
+  const state = ctx.state;
+  const encounter = state.activeEncounter;
+  if (!encounter) {
+    say(ctx, "system", "There is nothing to face here.");
+    return finish(ctx);
+  }
+  const option = encounter.options.find(o => o.kind === kind);
+  if (!option || !option.available) {
+    say(ctx, "system", option?.unavailableReason ?? "That isn't a choice you have.");
+    return finish(ctx);
+  }
+
+  if (kind === "fight") {
+    say(ctx, "encounter", "You set your feet and meet it.");
+    return finish(ctx);
+  }
+
+  const result = resolveOption({
+    encounter,
+    kind,
+    character: deps.character,
+    lightState: getLightState(state.lamp),
+    packRatio: packRatio(deps),
+    alertnessLevel: getThreatLevelFromPoints(state.alertness),
+    rng,
+    roomId: state.currentRoomId
+  });
+  return concludeBeat(ctx, deps, rng, result, { via: kind });
+}
+
+function doFightBeat(
+  ctx: Ctx,
+  deps: DelveRunDeps,
+  rng: Rng,
+  stance: "press" | "guard" | "breakAway"
+): DelveActionResult {
+  const state = ctx.state;
+  const encounter = state.activeEncounter;
+  if (!encounter) {
+    say(ctx, "system", "There is nothing to fight here.");
+    return finish(ctx);
+  }
+  const result = resolveFightBeat({
+    encounter,
+    stance,
+    character: deps.character,
+    rng,
+    lightState: getLightState(state.lamp),
+    roomId: state.currentRoomId
+  });
+  return concludeBeat(ctx, deps, rng, result, { via: stance });
+}
+
+function concludeBeat(
+  ctx: Ctx,
+  deps: DelveRunDeps,
+  rng: Rng,
+  result: ReturnType<typeof resolveFightBeat>,
+  origin: { via: string }
+): DelveActionResult {
+  const state = ctx.state;
+  const encounter = state.activeEncounter!;
+  const hunterId = encounter.hunterId;
+  const roomWhereItHappened = state.currentRoomId;
+
+  state.lamp = spendOil(state.lamp, result.oilAction);
+
+  for (const line of result.prose) {
+    say(ctx, "encounter", line);
+  }
+  if (result.playerHpDelta !== 0) {
+    ctx.events.push({ kind: "hpDelta", amount: result.playerHpDelta });
+  }
+  if (origin.via === "throwRations" && result.outcome === "escaped") {
+    ctx.events.push({ kind: "itemConsumed", tag: "ration" });
+  }
+
+  let excludeFromTick: string | undefined;
+
+  if (!result.over) {
+    // The beat resolved but the fight goes on.
+    state.activeEncounter = {
+      ...encounter,
+      enemyHp: Math.max(0, encounter.enemyHp + result.enemyHpDelta),
+      beat: encounter.beat + 1,
+      log: [...encounter.log, ...result.prose]
+    };
+  } else {
+    state.activeEncounter = undefined;
+    switch (result.outcome) {
+      case "dead": {
+        state.status = "dead";
+        ctx.events.push({ kind: "died" });
+        break;
+      }
+      case "won": {
+        state.hunters = state.hunters.filter(h => h.id !== hunterId);
+        ctx.events.push({ kind: "enemyDefeated", hunterId, enemyId: encounter.enemyId });
+        dropHunterLoot(ctx, roomWhereItHappened, rng);
+        break;
+      }
+      case "escaped": {
+        excludeFromTick = hunterId;
+        if (origin.via === "fallBack" || origin.via === "breakAway") {
+          // The player gives ground; the hunter keeps the room.
+          if (state.cameFromRoomId) {
+            movePlayer(ctx, state.cameFromRoomId);
+          } else {
+            displaceHunter(ctx, hunterId, rng);
+          }
+        } else {
+          // slipPast / parley / throwRations / lure: the hunter loses you.
+          displaceHunter(ctx, hunterId, rng);
+        }
+        break;
+      }
+    }
+  }
+
+  if (state.status !== "dead") {
+    // The fight was loud: hunters tick after the encounter resolves.
+    applySimTick(ctx, deps, rng, [result.noise], excludeFromTick ?? state.activeEncounter?.hunterId);
+  }
+  return finish(ctx);
+}
+
+// --- winch ---------------------------------------------------------------
+
+function doCrank(ctx: Ctx, deps: DelveRunDeps, rng: Rng, extractId: string): DelveActionResult {
+  const state = ctx.state;
+  const extract = findExtract(ctx, extractId);
+  if (!extract) return finish(ctx);
+  if (extract.condition !== "cranked") {
+    say(ctx, "system", "There is nothing to crank here.");
+    return finish(ctx);
+  }
+  if (extract.roomId !== state.currentRoomId) {
+    say(ctx, "system", "The winch is not in this room.");
+    return finish(ctx);
+  }
+
+  const required = extract.cranksRequired ?? 1;
+  const done = state.cranksDone[extractId] ?? 0;
+  if (done >= required) {
+    say(ctx, "system", "The cage already waits at the top of the shaft.");
+    return finish(ctx);
+  }
+
+  state.lamp = spendOil(state.lamp, "crank");
+  state.cranksDone = { ...state.cranksDone, [extractId]: done + 1 };
+  const noise: NoiseEvent = { roomId: state.currentRoomId, loudness: NOISE_LOUDNESS.crank, cause: "crank" };
+
+  if (done + 1 >= required) {
+    say(ctx, "action", "One last heave and the cage slams home at the top of the shaft. The whole warren heard that.");
+  } else {
+    say(ctx, "action", `You throw your weight on the crank. The cage grinds ${done + 1 === 1 ? "upward" : "higher"}, screaming on its rope. (${done + 1}/${required})`);
+  }
+  applySimTick(ctx, deps, rng, [noise]);
+  return finish(ctx);
+}
+
+// --- extract ---------------------------------------------------------------
+
+function findExtract(ctx: Ctx, extractId: string): PlaceExtract | undefined {
+  const floor = floorData(ctx.state.placeId, ctx.state.floor);
+  const extract = floor.extracts.find(e => e.id === extractId);
+  if (!extract) {
+    say(ctx, "system", "No way out goes by that name here.");
+    return undefined;
+  }
+  return extract;
+}
+
+function doExtract(ctx: Ctx, extractId: string): DelveActionResult {
+  const state = ctx.state;
+  const extract = findExtract(ctx, extractId);
+  if (!extract) return finish(ctx);
+  if (extract.roomId !== state.currentRoomId) {
+    say(ctx, "system", "That way out is not in this room.");
+    return finish(ctx);
+  }
+
+  switch (extract.condition) {
+    case "alwaysOpen":
+      break;
+    case "closesAtAlertness": {
+      const level = getThreatLevelFromPoints(state.alertness);
+      if (level >= (extract.alertnessLevel ?? Number.POSITIVE_INFINITY)) {
+        say(ctx, "system", "The door is barred from the other side now. They knew you'd try the way you came.");
+        return finish(ctx);
+      }
+      break;
+    }
+    case "waterClock": {
+      if (state.waterClock <= 0) {
+        say(ctx, "system", "Black water has taken the stair to the ceiling. Whatever window there was, it closed.");
+        return finish(ctx);
+      }
+      break;
+    }
+    case "cranked": {
+      const required = extract.cranksRequired ?? 1;
+      if ((state.cranksDone[extractId] ?? 0) < required) {
+        say(ctx, "system", "The cage hangs partway down the shaft. The winch wants more cranking before it will carry you.");
+        return finish(ctx);
+      }
+      break;
+    }
+  }
+
+  state.status = "extracted";
+  say(ctx, "system", `${extract.label}: you take it, and the Warrens let you go.`);
+  ctx.events.push({ kind: "extracted", extractId });
+  return finish(ctx);
+}
+
+// --- descend ---------------------------------------------------------------
+
+function doDescend(ctx: Ctx, stairRoomId: string): DelveActionResult {
+  const state = ctx.state;
+  if (stairRoomId !== state.currentRoomId) {
+    say(ctx, "system", "The way down is not in this room.");
+    return finish(ctx);
+  }
+  const place = getPlace(state.placeId);
+  const nextFloorNumber = state.floor + 1;
+  const nextFloor = place.floors.find(f => f.floor === nextFloorNumber);
+  if (!nextFloor) {
+    say(ctx, "system", "The Warrens go no deeper than this. Or if they do, you can't find the way.");
+    return finish(ctx);
+  }
+
+  const rng = createRng(`${state.seed}:populate:${nextFloorNumber}`);
+  const populated = populateFloor({ floor: nextFloor, rng, tier: state.tier });
+
+  state.floor = nextFloorNumber;
+  // Carryover: mirror createThreatStateWithCarryover's ratio — the floor
+  // below has heard some of the racket above.
+  state.alertness = Math.floor(state.alertness * DEPTH_RULES.floorThreatCarryoverRatio);
+  state.hunters = spawnFloorHunters(nextFloor, populated.hunterSpawnRoomIds, place.biome, state.tier, rng);
+  state.doorOverrides = { ...state.doorOverrides, ...populated.doorOverrides };
+  state.roomProse = { ...state.roomProse, ...populated.roomProse };
+  state.lootRoomIds = [...state.lootRoomIds, ...populated.lootRoomIds];
+  state.supplyCaches = [
+    ...state.supplyCaches,
+    ...populated.supplyRoomIds.map((s): DelveSupplyCache => ({ ...s, found: false }))
+  ];
+  state.cameFromRoomId = undefined;
+  state.currentRoomId = nextFloor.entranceRoomId;
+  if (!state.visitedRoomIds.includes(nextFloor.entranceRoomId)) {
+    state.visitedRoomIds = [...state.visitedRoomIds, nextFloor.entranceRoomId];
+  }
+
+  say(ctx, "system", "You take the stair down. The air changes its mind about you.");
+  appendRoomProse(ctx, nextFloor.entranceRoomId, true);
+  ctx.events.push({ kind: "descended", floor: nextFloorNumber });
+  return finish(ctx);
+}

--- a/src/game/delve/encounters.ts
+++ b/src/game/delve/encounters.ts
@@ -485,6 +485,17 @@ export function resolveOption(params: {
     }
 
     case "lure": {
+      // Options are computed at contact and can go stale mid-encounter; the
+      // lamp may have died since. In the dark there is no misdirection.
+      if (lightState === "dark") {
+        return degradeToFightWithFreeExchange({
+          encounter,
+          character,
+          rng,
+          roomId,
+          prose: ["Without light there is nothing to lead it toward. It comes on."]
+        });
+      }
       const chance = lureChance(agilityMod);
       if (rng.nextFloat() < chance) {
         const noise: NoiseEvent = { roomId, loudness: 2, cause: "other" };

--- a/src/game/delve/encounters.ts
+++ b/src/game/delve/encounters.ts
@@ -1,0 +1,666 @@
+// Inline encounters (Pillar 4): decision-set assembly + beat resolution.
+// Pure, React-free. Resolves contact with a hunter in 1-3 weighty beats
+// instead of a combat screen, reusing the swing-level math in ../combat.ts
+// rather than duplicating accuracy/evasion/armor/damage formulas.
+// See docs/design/the-delve.md.
+
+import type {
+  ActiveEncounter,
+  EncounterBeatResult,
+  EncounterOption,
+  EncounterOptionKind,
+  FightStance,
+  Hunter,
+  LightState,
+  NoiseEvent,
+  OilAction
+} from "./types";
+import type { Character, EnemyInstance, ItemInstance } from "../types";
+import type { Rng } from "../rng";
+import { getEnemy } from "../../data/enemies";
+import { buildEnemyInstance } from "../encounterGenerator";
+import { rollD20, rollDice } from "../dice";
+import { getModifier } from "../characterMath";
+import { COMBAT_RULES } from "../constants";
+import { getDamageBonus, guessWeaponDice } from "../combat";
+import { moveNoiseLoudness, NOISE_LOUDNESS } from "./noise";
+
+// ---------------------------------------------------------------------------
+// Contract note (see final report): EncounterBeatResult has no field for the
+// OilAction the design doc asks every beat/option resolution to report
+// ("costs 1 oil (return the OilAction; the run layer spends it)"). Rather
+// than editing types.ts, this module returns a superset that is structurally
+// still an EncounterBeatResult.
+// ---------------------------------------------------------------------------
+export interface DelveEncounterBeatResult extends EncounterBeatResult {
+  oilAction: OilAction;
+}
+
+// ---------------------------------------------------------------------------
+// Tuning constants (documented judgment calls; see docs/design/the-delve.md
+// Pillar 4). Every chance is clamped to keep both success and failure always
+// reachable.
+// ---------------------------------------------------------------------------
+
+const SLIP_BASE_CHANCE = 0.6;
+const SLIP_PACK_PENALTY = 0.3; // full penalty at 100% pack capacity
+const SLIP_DIM_PENALTY = 0.15;
+const SLIP_AGILITY_SCALE = 0.05; // matches the agility scaling combat.ts uses for flee chance
+const SLIP_MIN = 0.05;
+const SLIP_MAX = 0.9;
+
+const FOLLOW_BASE_CHANCE = 0.2;
+const FOLLOW_ALERTNESS_SCALE = 0.12;
+const FOLLOW_MAX_CHANCE = 0.85;
+
+const PARLEY_BASE_CHANCE = 0.45;
+const PARLEY_PRESENCE_SCALE = 0.05;
+const PARLEY_MIN = 0.1;
+const PARLEY_MAX = 0.85;
+
+const THROW_RATIONS_CHANCE = 0.75;
+
+const LURE_BASE_CHANCE = 0.55;
+const LURE_AGILITY_SCALE = 0.04;
+const LURE_MIN = 0.15;
+const LURE_MAX = 0.9;
+
+const BREAK_AWAY_BASE_CHANCE = 0.3;
+const BREAK_AWAY_WORN_ENEMY_BONUS = 0.4; // scales with how depleted the enemy's hp is
+const BREAK_AWAY_AGILITY_SCALE = 0.05;
+const BREAK_AWAY_MIN = 0.1;
+const BREAK_AWAY_MAX = 0.9;
+
+/**
+ * Fight-beat aggregation: each beat is "roughly 2.5 swings per side" per the
+ * design doc. Press leans aggressive (more, harder swings; guards less, so
+ * the enemy also swings more and hits easier). Guard trims both sides down
+ * and rewards a clean parry with a small counter. The fractional swing count
+ * becomes a probabilistic bonus swing so beats don't always resolve on the
+ * same number of dice rolls.
+ */
+interface StanceProfile {
+  playerSwings: number;
+  playerAccuracyMod: number;
+  playerDamageMultiplier: number;
+  enemySwings: number;
+  enemyAccuracyMod: number;
+  enemyDamageMultiplier: number;
+}
+
+const STANCE_PROFILES: Record<"press" | "guard", StanceProfile> = {
+  press: {
+    playerSwings: 3,
+    playerAccuracyMod: 1,
+    playerDamageMultiplier: 1.15,
+    enemySwings: 3,
+    enemyAccuracyMod: 1, // "guards less": easier for the enemy to land its own hits
+    enemyDamageMultiplier: 1
+  },
+  guard: {
+    playerSwings: 2,
+    playerAccuracyMod: 0,
+    playerDamageMultiplier: 0.85,
+    enemySwings: 2,
+    enemyAccuracyMod: 0,
+    enemyDamageMultiplier: 0.5 // reuses COMBAT_RULES.defendDamageReduction's magnitude
+  }
+};
+
+/** Small accuracy penalty applied to the player's fight-beat swings; the
+ * lamp's light states make aiming worse before they make sneaking impossible. */
+function lightAccuracyPenalty(lightState: LightState): number {
+  switch (lightState) {
+    case "dim": return -1;
+    case "dark": return -2;
+    case "bright": return 0;
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+// ---------------------------------------------------------------------------
+// Decision-set assembly
+// ---------------------------------------------------------------------------
+
+/**
+ * Chance to slip past a hunter without a fight. Heavier packs and dimmer
+ * light both make it worse; agility helps, at the same scale combat.ts uses
+ * for flee chance (getModifier(agility) * 0.05).
+ */
+export function slipChance(params: {
+  packRatio: number;
+  lightState: LightState;
+  agilityModifier: number;
+}): number {
+  if (params.lightState === "dark") return 0; // never offered in the dark; kept honest for callers that ask anyway
+  let chance = SLIP_BASE_CHANCE;
+  chance -= Math.max(0, params.packRatio) * SLIP_PACK_PENALTY;
+  if (params.lightState === "dim") chance -= SLIP_DIM_PENALTY;
+  chance += params.agilityModifier * SLIP_AGILITY_SCALE;
+  return clamp(chance, SLIP_MIN, SLIP_MAX);
+}
+
+/** Chance a hunter follows through a fall-back; rises with how awake the place is. */
+function hunterFollowChance(alertnessLevel: number): number {
+  return Math.min(FOLLOW_MAX_CHANCE, FOLLOW_BASE_CHANCE + Math.max(0, alertnessLevel) * FOLLOW_ALERTNESS_SCALE);
+}
+
+function parleyChance(character: Character): number {
+  return clamp(
+    PARLEY_BASE_CHANCE + getModifier(character.abilityScores.presence) * PARLEY_PRESENCE_SCALE,
+    PARLEY_MIN,
+    PARLEY_MAX
+  );
+}
+
+function lureChance(agilityModifier: number): number {
+  return clamp(LURE_BASE_CHANCE + agilityModifier * LURE_AGILITY_SCALE, LURE_MIN, LURE_MAX);
+}
+
+function breakAwayChance(enemyHpRatio: number, agilityModifier: number): number {
+  const wornBonus = (1 - clamp(enemyHpRatio, 0, 1)) * BREAK_AWAY_WORN_ENEMY_BONUS;
+  return clamp(
+    BREAK_AWAY_BASE_CHANCE + wornBonus + agilityModifier * BREAK_AWAY_AGILITY_SCALE,
+    BREAK_AWAY_MIN,
+    BREAK_AWAY_MAX
+  );
+}
+
+/**
+ * Heuristic for which enemies can be reasoned with: goblins are organized
+ * raiders with language and self-interest (lootTags include "goblin"), so
+ * parley is on the table. Vermin, beasts, spirits, and stone/undead
+ * constructs (rats, beetles, hounds, wisps, husks, slimes, gargoyles,
+ * skeletons, leeches) cannot be talked to. Conservative on purpose — extend
+ * this only when a place adds another clearly-sapient bestiary entry.
+ */
+function isParleyable(enemyDef: ReturnType<typeof getEnemy>): boolean {
+  return enemyDef.lootTags.includes("goblin");
+}
+
+function buildSlipOption(lightState: LightState): EncounterOption {
+  const available = lightState !== "dark";
+  return {
+    kind: "slipPast",
+    label: "Slip along the far wall",
+    available,
+    unavailableReason: available ? undefined : "No light to slip by"
+  };
+}
+
+function buildFallBackOption(cameFromRoomId?: string): EncounterOption {
+  const available = Boolean(cameFromRoomId);
+  return {
+    kind: "fallBack",
+    label: "Fall back the way you came",
+    available,
+    unavailableReason: available ? undefined : "Nowhere behind you"
+  };
+}
+
+function buildParleyOption(enemyDef: ReturnType<typeof getEnemy>): EncounterOption {
+  const available = isParleyable(enemyDef);
+  return {
+    kind: "parley",
+    label: "Try words, not blades",
+    available,
+    unavailableReason: available ? undefined : "It won't understand you"
+  };
+}
+
+function buildThrowRationsOption(carriedItems: ItemInstance[]): EncounterOption {
+  const available = carriedItems.some(item => item.tags?.includes("ration"));
+  return {
+    kind: "throwRations",
+    label: "Toss the rations and hope it bites",
+    available,
+    unavailableReason: available ? undefined : "No rations to spare"
+  };
+}
+
+function buildLureOption(lightState: LightState, adjacentRoomIds: string[]): EncounterOption {
+  const available = lightState === "bright" && adjacentRoomIds.length > 0;
+  let reason: string | undefined;
+  if (!available) {
+    reason = lightState !== "bright" ? "Not enough light to lead it away" : "Nowhere to lead it";
+  }
+  return { kind: "lure", label: "Lead it toward the dark ahead", available, unavailableReason: reason };
+}
+
+const LIGHT_APPRAISAL_LINES: Record<LightState, string> = {
+  bright: "The lamp holds steady; you have it in full view.",
+  dim: "The lamp gutters low, and the shape of it blurs at the edges.",
+  dark: "You cannot see it. You can hear it, close."
+};
+
+function buildAppraisalProse(enemyDef: ReturnType<typeof getEnemy>, lightState: LightState): string[] {
+  return [enemyDef.description, LIGHT_APPRAISAL_LINES[lightState]];
+}
+
+/**
+ * Open an encounter on contact with a hunter: appraisal prose plus the
+ * context-assembled decision set (Pillar 4). Note this signature carries a
+ * few params ("carriedItems", "alertnessLevel", "adjacentRoomIds", not in
+ * the design doc's shorthand list) needed to derive throwRations/parley/lure
+ * availability and the fall-back follow chance — see final report.
+ */
+export function openEncounter(params: {
+  hunter: Hunter;
+  character: Character;
+  carriedItems: ItemInstance[];
+  lightState: LightState;
+  packRatio: number;
+  cameFromRoomId?: string;
+  alertnessLevel: number;
+  adjacentRoomIds: string[];
+  rng: Rng;
+}): ActiveEncounter {
+  const { hunter, carriedItems, lightState, cameFromRoomId, adjacentRoomIds, rng } = params;
+  const enemyDef = getEnemy(hunter.enemyId);
+  const enemyInstance = buildEnemyInstance(hunter.enemyId, rng.forkChild(`${hunter.id}:stats`), 1);
+
+  const options: EncounterOption[] = [
+    { kind: "fight", label: "Meet it head-on", available: true },
+    buildSlipOption(lightState),
+    buildFallBackOption(cameFromRoomId),
+    buildParleyOption(enemyDef),
+    buildThrowRationsOption(carriedItems),
+    buildLureOption(lightState, adjacentRoomIds)
+  ];
+
+  return {
+    hunterId: hunter.id,
+    enemyId: hunter.enemyId,
+    enemyHp: enemyInstance.hp,
+    enemyMaxHp: enemyInstance.maxHp,
+    beat: 1,
+    options,
+    log: buildAppraisalProse(enemyDef, lightState)
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Swing primitives — thin wrappers over ../combat.ts and ../dice.ts, not
+// reimplementations. Kept local because combat.ts's per-turn functions are
+// tied to CombatState/EnemyInstance[] shapes the delve encounter doesn't use.
+// ---------------------------------------------------------------------------
+
+interface SwingResult {
+  hit: boolean;
+  damage: number;
+}
+
+function playerSwing(params: {
+  character: Character;
+  enemy: EnemyInstance;
+  accuracyMod: number;
+  damageMultiplier: number;
+  lightState: LightState;
+  rng: Rng;
+}): SwingResult {
+  const { character, enemy, accuracyMod, damageMultiplier, lightState, rng } = params;
+  const roll = rollD20(rng);
+  const accuracy = character.derivedStats.accuracy + accuracyMod + lightAccuracyPenalty(lightState);
+  const total = roll + accuracy;
+  const isCrit = roll === COMBAT_RULES.naturalCrit;
+  const isFumble = roll === COMBAT_RULES.naturalFumble;
+  const hit = !isFumble && (isCrit || total >= enemy.evasion);
+  if (!hit) return { hit: false, damage: 0 };
+
+  const weapon = character.equipped.weapon;
+  const dice = guessWeaponDice(weapon ?? ({ tags: [] } as unknown as ItemInstance));
+  let damage = rollDice(dice, rng) + getDamageBonus(character, weapon);
+  if (isCrit) damage *= COMBAT_RULES.critMultiplier;
+  damage = Math.max(1, damage - enemy.armor);
+  damage = Math.max(0, Math.round(damage * damageMultiplier));
+  return { hit: true, damage };
+}
+
+function enemySwing(params: {
+  character: Character;
+  enemy: EnemyInstance;
+  accuracyMod: number;
+  damageMultiplier: number;
+  rng: Rng;
+}): SwingResult {
+  const { character, enemy, accuracyMod, damageMultiplier, rng } = params;
+  const roll = rollD20(rng);
+  const accuracy = enemy.accuracy + accuracyMod;
+  const total = roll + accuracy;
+  const isCrit = roll === COMBAT_RULES.naturalCrit;
+  const isFumble = roll === COMBAT_RULES.naturalFumble;
+  const hit = !isFumble && (isCrit || total >= character.derivedStats.evasion);
+  if (!hit) return { hit: false, damage: 0 };
+
+  let damage = rollDice(enemy.damageDice, rng);
+  if (isCrit) damage *= COMBAT_RULES.critMultiplier;
+  damage = Math.max(1, damage - character.derivedStats.armor);
+  damage = Math.max(0, Math.round(damage * damageMultiplier));
+  return { hit: true, damage };
+}
+
+function enemyInstanceFor(encounterEnemyId: string, hunterId: string, rng: Rng): EnemyInstance {
+  // Only `instanceId` is randomized inside buildEnemyInstance; every other
+  // stat is a pure function of (enemyId, depthTier). Forking off a fixed
+  // label keeps this call from disturbing the rng stream the caller uses
+  // for its own swing rolls.
+  return buildEnemyInstance(encounterEnemyId, rng.forkChild(`${hunterId}:stats`), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Non-fight option resolution
+// ---------------------------------------------------------------------------
+
+function degradeToFightWithFreeExchange(params: {
+  encounter: ActiveEncounter;
+  character: Character;
+  rng: Rng;
+  roomId: string;
+  prose: string[];
+}): DelveEncounterBeatResult {
+  const { encounter, character, rng, roomId, prose } = params;
+  const enemy = enemyInstanceFor(encounter.enemyId, encounter.hunterId, rng);
+  // The enemy gets an unanswered swing — the option failed because it saw
+  // you first, so it strikes before you can set your feet. +1 accuracy
+  // documents that opening advantage.
+  const swing = enemySwing({ character, enemy, accuracyMod: 1, damageMultiplier: 1, rng });
+  const playerHpDelta = -swing.damage;
+  const noise: NoiseEvent = { roomId, loudness: NOISE_LOUDNESS.fightBeat, cause: "fightBeat" };
+  const lines = [
+    ...prose,
+    swing.hit ? "It gets a free strike in before you can answer." : "It lunges, but you twist clear of the worst of it."
+  ];
+  const playerHpAfter = character.hp + playerHpDelta;
+  if (playerHpAfter <= 0) {
+    return { prose: lines, playerHpDelta, enemyHpDelta: 0, noise, over: true, outcome: "dead", oilAction: "encounterBeat" };
+  }
+  return { prose: lines, playerHpDelta, enemyHpDelta: 0, noise, over: false, oilAction: "encounterBeat" };
+}
+
+/**
+ * Resolve a non-fight decision (slipPast / fallBack / parley / throwRations /
+ * lure). A failed slipPast or fallBack — and, for consistency, a failed
+ * parley/throwRations/lure — degrades into the fight at beat 1 with the
+ * enemy getting a free exchange, per the design doc.
+ */
+export function resolveOption(params: {
+  encounter: ActiveEncounter;
+  kind: Exclude<EncounterOptionKind, "fight">;
+  character: Character;
+  lightState: LightState;
+  packRatio: number;
+  alertnessLevel: number;
+  rng: Rng;
+  roomId: string;
+}): DelveEncounterBeatResult {
+  const { encounter, kind, character, lightState, packRatio, alertnessLevel, rng, roomId } = params;
+  const enemyLabel = getEnemy(encounter.enemyId).name;
+  const agilityMod = getModifier(character.abilityScores.agility);
+
+  switch (kind) {
+    case "slipPast": {
+      const chance = slipChance({ packRatio, lightState, agilityModifier: agilityMod });
+      if (rng.nextFloat() < chance) {
+        const noise: NoiseEvent = { roomId, loudness: moveNoiseLoudness({ packRatio, lightState }), cause: "move" };
+        return {
+          prose: [`You slip past ${enemyLabel} while it's looking the wrong way.`, "The passage swallows the sound of your steps."],
+          playerHpDelta: 0,
+          enemyHpDelta: 0,
+          noise,
+          over: true,
+          outcome: "escaped",
+          oilAction: "encounterBeat"
+        };
+      }
+      return degradeToFightWithFreeExchange({
+        encounter,
+        character,
+        rng,
+        roomId,
+        prose: ["You break from cover a half-step too soon.", `${enemyLabel} turns before you clear the wall.`]
+      });
+    }
+
+    case "fallBack": {
+      const chance = 1 - hunterFollowChance(alertnessLevel);
+      if (rng.nextFloat() < chance) {
+        const noise: NoiseEvent = { roomId, loudness: moveNoiseLoudness({ packRatio, lightState }), cause: "move" };
+        return {
+          prose: ["You give ground, back through the way you came.", `${enemyLabel} doesn't follow.`],
+          playerHpDelta: 0,
+          enemyHpDelta: 0,
+          noise,
+          over: true,
+          outcome: "escaped",
+          oilAction: "encounterBeat"
+        };
+      }
+      return degradeToFightWithFreeExchange({
+        encounter,
+        character,
+        rng,
+        roomId,
+        prose: [`You give ground, but ${enemyLabel} is faster.`]
+      });
+    }
+
+    case "parley": {
+      const chance = parleyChance(character);
+      if (rng.nextFloat() < chance) {
+        const noise: NoiseEvent = { roomId, loudness: 1, cause: "other" };
+        return {
+          prose: ["You raise empty hands and speak low, offering terms.", `${enemyLabel} weighs it, then backs off, muttering.`],
+          playerHpDelta: 0,
+          enemyHpDelta: 0,
+          noise,
+          over: true,
+          outcome: "escaped",
+          oilAction: "encounterBeat"
+        };
+      }
+      return degradeToFightWithFreeExchange({
+        encounter,
+        character,
+        rng,
+        roomId,
+        prose: [`You try words. ${enemyLabel} isn't in the mood.`]
+      });
+    }
+
+    case "throwRations": {
+      if (rng.nextFloat() < THROW_RATIONS_CHANCE) {
+        const noise: NoiseEvent = { roomId, loudness: 2, cause: "other" };
+        return {
+          prose: ["You lob the rations into the dark.", `${enemyLabel} scrabbles after the food, forgetting you.`],
+          playerHpDelta: 0,
+          enemyHpDelta: 0,
+          noise,
+          over: true,
+          outcome: "escaped",
+          oilAction: "encounterBeat"
+        };
+      }
+      return degradeToFightWithFreeExchange({
+        encounter,
+        character,
+        rng,
+        roomId,
+        prose: [`The rations hit the floor. ${enemyLabel} doesn't care.`]
+      });
+    }
+
+    case "lure": {
+      const chance = lureChance(agilityMod);
+      if (rng.nextFloat() < chance) {
+        const noise: NoiseEvent = { roomId, loudness: 2, cause: "other" };
+        return {
+          prose: ["You feint toward the next passage and let it give chase.", `${enemyLabel} takes the bait, blundering past you.`],
+          playerHpDelta: 0,
+          enemyHpDelta: 0,
+          noise,
+          over: true,
+          outcome: "escaped",
+          oilAction: "encounterBeat"
+        };
+      }
+      return degradeToFightWithFreeExchange({
+        encounter,
+        character,
+        rng,
+        roomId,
+        prose: ["It doesn't take the feint."]
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fight-beat resolution
+// ---------------------------------------------------------------------------
+
+const STANCE_VERBS: Record<"press" | "guard", { hit: string; miss: string }> = {
+  press: { hit: "You bull in and put steel where it counts.", miss: "You bull in, but it turns aside at the last." },
+  guard: { hit: "You hold the guard and answer where you can.", miss: "You hold the guard; nothing gets through." }
+};
+
+function buildFightBeatProse(params: {
+  stance: "press" | "guard";
+  playerDamage: number;
+  enemyDamage: number;
+  lightState: LightState;
+  outcome?: EncounterBeatResult["outcome"];
+}): string[] {
+  const { stance, playerDamage, enemyDamage, lightState, outcome } = params;
+  const lines: string[] = [STANCE_VERBS[stance][playerDamage > 0 ? "hit" : "miss"]];
+  lines.push(enemyDamage > 0 ? "It answers back, and the blow lands." : "It swings and finds nothing but air.");
+  if (lightState === "dim" && playerDamage === 0) {
+    lines.push("The dim lamp cost you the opening.");
+  }
+  if (outcome === "won") {
+    lines.push("It goes down and stays down.");
+  } else if (outcome === "dead") {
+    lines.push("Your lamp gutters. The floor tilts up to meet you.");
+  }
+  return lines;
+}
+
+function buildBreakAwayProse(params: { success: boolean; parting: SwingResult; lightState: LightState }): string[] {
+  const lines: string[] = [
+    params.success ? "You wrench free of the exchange." : "You try to wrench free, but it keeps hold of the fight."
+  ];
+  lines.push(params.parting.hit ? "It gets one parting cut in as you go." : "It swings after you and misses.");
+  if (params.lightState === "dark" && params.parting.hit) {
+    lines.push("You can't see how bad it is, only that it hurts.");
+  }
+  return lines;
+}
+
+/**
+ * Resolve one fight beat. Press and guard aggregate ~2.5 swings per side
+ * over the existing combat math (see StanceProfile above); breakAway
+ * attempts to end the encounter outright, taking a parting exchange either
+ * way and always emitting "flee" noise (loudness 4) rather than "fightBeat"
+ * (loudness 3), per the design doc's noise table.
+ */
+export function resolveFightBeat(params: {
+  encounter: ActiveEncounter;
+  stance: FightStance;
+  character: Character;
+  rng: Rng;
+  lightState: LightState;
+  roomId: string;
+}): DelveEncounterBeatResult {
+  const { encounter, stance, character, rng, lightState, roomId } = params;
+  const enemy = enemyInstanceFor(encounter.enemyId, encounter.hunterId, rng);
+
+  if (stance === "breakAway") {
+    const enemyHpRatio = encounter.enemyMaxHp > 0 ? encounter.enemyHp / encounter.enemyMaxHp : 0;
+    const agilityMod = getModifier(character.abilityScores.agility);
+    const chance = breakAwayChance(enemyHpRatio, agilityMod);
+    const success = rng.nextFloat() < chance;
+    // A parting exchange happens regardless of whether the break succeeds —
+    // glancing, since you're already moving (0.75x damage).
+    const parting = enemySwing({ character, enemy, accuracyMod: 0, damageMultiplier: 0.75, rng });
+    const playerHpDelta = -parting.damage;
+    const noise: NoiseEvent = { roomId, loudness: NOISE_LOUDNESS.flee, cause: "flee" };
+    const prose = buildBreakAwayProse({ success, parting, lightState });
+    const playerHpAfter = character.hp + playerHpDelta;
+    if (playerHpAfter <= 0) {
+      return { prose, playerHpDelta, enemyHpDelta: 0, noise, over: true, outcome: "dead", oilAction: "encounterBeat" };
+    }
+    if (success) {
+      return { prose, playerHpDelta, enemyHpDelta: 0, noise, over: true, outcome: "escaped", oilAction: "encounterBeat" };
+    }
+    return { prose, playerHpDelta, enemyHpDelta: 0, noise, over: false, oilAction: "encounterBeat" };
+  }
+
+  const profile = STANCE_PROFILES[stance];
+
+  let playerDamage = 0;
+  const playerSwingCount = Math.floor(profile.playerSwings) +
+    (rng.nextFloat() < profile.playerSwings - Math.floor(profile.playerSwings) ? 1 : 0);
+  for (let i = 0; i < playerSwingCount; i++) {
+    const swing = playerSwing({
+      character,
+      enemy,
+      accuracyMod: profile.playerAccuracyMod,
+      damageMultiplier: profile.playerDamageMultiplier,
+      lightState,
+      rng
+    });
+    playerDamage += swing.damage;
+  }
+
+  let enemyDamage = 0;
+  let anyEnemyMiss = false;
+  const enemySwingCount = Math.floor(profile.enemySwings) +
+    (rng.nextFloat() < profile.enemySwings - Math.floor(profile.enemySwings) ? 1 : 0);
+  for (let i = 0; i < enemySwingCount; i++) {
+    const swing = enemySwing({
+      character,
+      enemy,
+      accuracyMod: profile.enemyAccuracyMod,
+      damageMultiplier: profile.enemyDamageMultiplier,
+      rng
+    });
+    enemyDamage += swing.damage;
+    if (!swing.hit) anyEnemyMiss = true;
+  }
+
+  if (stance === "guard" && anyEnemyMiss) {
+    // Small counter: a whiffed enemy swing while holding the guard earns one
+    // extra, weaker player swing (low accuracy bonus offset, reduced damage).
+    const counter = playerSwing({
+      character,
+      enemy,
+      accuracyMod: -2,
+      damageMultiplier: 0.6,
+      lightState,
+      rng
+    });
+    playerDamage += counter.damage;
+  }
+
+  const enemyHpDelta = -playerDamage;
+  const playerHpDelta = -enemyDamage;
+  const noise: NoiseEvent = { roomId, loudness: NOISE_LOUDNESS.fightBeat, cause: "fightBeat" };
+  const enemyHpAfter = Math.max(0, encounter.enemyHp + enemyHpDelta);
+  const playerHpAfter = character.hp + playerHpDelta;
+
+  let over = false;
+  let outcome: EncounterBeatResult["outcome"];
+  if (playerHpAfter <= 0) {
+    over = true;
+    outcome = "dead";
+  } else if (enemyHpAfter <= 0) {
+    over = true;
+    outcome = "won";
+  }
+
+  const prose = buildFightBeatProse({ stance, playerDamage, enemyDamage, lightState, outcome });
+
+  return { prose, playerHpDelta, enemyHpDelta, noise, over, outcome, oilAction: "encounterBeat" };
+}

--- a/src/game/delve/encounters.ts
+++ b/src/game/delve/encounters.ts
@@ -25,16 +25,8 @@ import { COMBAT_RULES } from "../constants";
 import { getDamageBonus, guessWeaponDice } from "../combat";
 import { moveNoiseLoudness, NOISE_LOUDNESS } from "./noise";
 
-// ---------------------------------------------------------------------------
-// Contract note (see final report): EncounterBeatResult has no field for the
-// OilAction the design doc asks every beat/option resolution to report
-// ("costs 1 oil (return the OilAction; the run layer spends it)"). Rather
-// than editing types.ts, this module returns a superset that is structurally
-// still an EncounterBeatResult.
-// ---------------------------------------------------------------------------
-export interface DelveEncounterBeatResult extends EncounterBeatResult {
-  oilAction: OilAction;
-}
+/** @deprecated The contract now carries oilAction; use EncounterBeatResult. */
+export type DelveEncounterBeatResult = EncounterBeatResult;
 
 // ---------------------------------------------------------------------------
 // Tuning constants (documented judgment calls; see docs/design/the-delve.md

--- a/src/game/delve/hunters.ts
+++ b/src/game/delve/hunters.ts
@@ -1,0 +1,209 @@
+// Positional hunter state machine (Pillar 3). Pure, seeded-rng, no React.
+// See docs/design/the-delve.md.
+
+import type { Direction, Hunter, HunterSignal, HunterState, NoiseEvent } from "./types";
+import type { RoomAdjacency } from "./noise";
+import { bfsPath, graphDistance, hunterHears } from "./noise";
+import type { Rng } from "../rng";
+import { makeId } from "../rng";
+
+/** Noise heard within this many rooms immediately promotes a hunter to hunting. */
+const HUNTING_HEAR_DISTANCE = 2;
+
+/** Alertness level at which sight (not just noise) can trigger hunting. */
+const HUNTING_SIGHT_ALERTNESS = 3;
+
+/** Roaming hunters' base chance to take a step each tick. */
+const ROAM_MOVE_CHANCE_BASE = 0.5;
+/** Roaming hunters' chance to move at maximum alertness. */
+const ROAM_MOVE_CHANCE_MAX = 0.8;
+/** Alertness level at which roaming move chance saturates at the max. */
+const ROAM_MOVE_CHANCE_SATURATION_LEVEL = 5;
+
+/** Pick which rooms get hunters and spin up their initial (dormant) state. */
+export function spawnHunters(params: {
+  floor: number;
+  rng: Rng;
+  budget: { min: number; max: number };
+  eligibleRoomIds: string[];
+  enemyPool: string[];
+}): Hunter[] {
+  const { rng, budget, eligibleRoomIds, enemyPool } = params;
+  if (eligibleRoomIds.length === 0 || enemyPool.length === 0) return [];
+
+  const count = Math.min(
+    eligibleRoomIds.length,
+    rng.nextInt(budget.min, budget.max)
+  );
+  const rooms = rng.shuffle(eligibleRoomIds).slice(0, count);
+
+  return rooms.map((roomId): Hunter => ({
+    id: makeId(rng, "hunter"),
+    enemyId: rng.pickOne(enemyPool),
+    roomId,
+    state: "dormant"
+  }));
+}
+
+/** Roaming hunters get bolder (more likely to move) as alertness rises. */
+export function roamMoveChance(alertnessLevel: number): number {
+  const t = Math.max(0, Math.min(1, alertnessLevel / ROAM_MOVE_CHANCE_SATURATION_LEVEL));
+  return ROAM_MOVE_CHANCE_BASE + t * (ROAM_MOVE_CHANCE_MAX - ROAM_MOVE_CHANCE_BASE);
+}
+
+/** The noise a hunter should chase: loudest first, nearest as a tiebreak. */
+function pickTargetNoise(
+  heard: Array<{ noise: NoiseEvent; distance: number }>
+): NoiseEvent | undefined {
+  if (heard.length === 0) return undefined;
+  const sorted = [...heard].sort((a, b) => {
+    if (b.noise.loudness !== a.noise.loudness) return b.noise.loudness - a.noise.loudness;
+    return a.distance - b.distance;
+  });
+  return sorted[0]!.noise;
+}
+
+/** One room step toward `targetRoomId`, or the current room if no path exists. */
+function stepToward(adjacency: RoomAdjacency, fromRoomId: string, targetRoomId: string): string {
+  const path = bfsPath(adjacency, fromRoomId, targetRoomId);
+  if (!path || path.length < 2) return fromRoomId;
+  return path[1]!;
+}
+
+function tickOne(
+  hunter: Hunter,
+  params: {
+    adjacency: RoomAdjacency;
+    playerRoomId: string;
+    noises: NoiseEvent[];
+    alertnessLevel: number;
+    rng: Rng;
+  }
+): Hunter {
+  const { adjacency, playerRoomId, noises, alertnessLevel, rng } = params;
+
+  // Hunting is sticky: once a hunter has you, it converges every tick.
+  if (hunter.state === "hunting") {
+    return {
+      ...hunter,
+      roomId: stepToward(adjacency, hunter.roomId, playerRoomId),
+      heardAt: undefined
+    };
+  }
+
+  const sees =
+    hunter.roomId === playerRoomId ||
+    (alertnessLevel >= HUNTING_SIGHT_ALERTNESS && (adjacency[hunter.roomId] ?? []).includes(playerRoomId));
+
+  const heard = noises
+    .filter(n => hunterHears(n, hunter.roomId, adjacency))
+    .map(n => ({ noise: n, distance: graphDistance(adjacency, n.roomId, hunter.roomId)! }));
+
+  const closeHeard = heard.some(h => h.distance <= HUNTING_HEAR_DISTANCE);
+
+  if (sees || closeHeard) {
+    return {
+      ...hunter,
+      state: "hunting",
+      roomId: stepToward(adjacency, hunter.roomId, playerRoomId),
+      heardAt: undefined
+    };
+  }
+
+  if (heard.length > 0) {
+    const target = pickTargetNoise(heard)!;
+
+    if (hunter.state === "dormant") {
+      // Wakes up this tick; starts moving next tick.
+      return { ...hunter, state: "drawn", heardAt: target.roomId };
+    }
+
+    if (hunter.state === "roaming") {
+      return { ...hunter, state: "drawn", heardAt: target.roomId };
+    }
+
+    // Already drawn: refresh the target and take a step toward it.
+    const heardAt = target.roomId;
+    const roomId = stepToward(adjacency, hunter.roomId, heardAt);
+    if (roomId === heardAt) {
+      return { ...hunter, state: "roaming", roomId, heardAt: undefined };
+    }
+    return { ...hunter, state: "drawn", roomId, heardAt };
+  }
+
+  if (hunter.state === "drawn" && hunter.heardAt) {
+    const roomId = stepToward(adjacency, hunter.roomId, hunter.heardAt);
+    if (roomId === hunter.heardAt) {
+      return { ...hunter, state: "roaming", roomId, heardAt: undefined };
+    }
+    return { ...hunter, roomId };
+  }
+
+  if (hunter.state === "roaming") {
+    const neighbors = adjacency[hunter.roomId] ?? [];
+    if (neighbors.length > 0 && rng.nextFloat() < roamMoveChance(alertnessLevel)) {
+      return { ...hunter, roomId: rng.pickOne(neighbors) };
+    }
+    return hunter;
+  }
+
+  // dormant, heard nothing: stays put.
+  return hunter;
+}
+
+/**
+ * Run one tick of the hunter simulation. Call after every player action.
+ * `directionOf` maps a room-to-room step to a compass direction for
+ * player-facing signal prose, keeping this module decoupled from place data.
+ */
+export function tickHunters(params: {
+  hunters: Hunter[];
+  adjacency: RoomAdjacency;
+  playerRoomId: string;
+  noises: NoiseEvent[];
+  alertnessLevel: number;
+  rng: Rng;
+  directionOf: (fromRoomId: string, toRoomId: string) => Direction | undefined;
+}): { hunters: Hunter[]; signals: HunterSignal[]; contacts: string[] } {
+  const { adjacency, playerRoomId, noises, alertnessLevel, rng, directionOf } = params;
+
+  const hunters = params.hunters.map(hunter =>
+    tickOne(hunter, { adjacency, playerRoomId, noises, alertnessLevel, rng })
+  );
+
+  const signals: HunterSignal[] = [];
+  for (const hunter of hunters) {
+    const distance = graphDistance(adjacency, playerRoomId, hunter.roomId);
+    if (distance === undefined || distance > 2) continue;
+
+    let direction: HunterSignal["direction"];
+    if (distance === 0) {
+      direction = "here";
+    } else {
+      const path = bfsPath(adjacency, playerRoomId, hunter.roomId);
+      const firstStep = path && path.length > 1 ? path[1] : undefined;
+      const resolved = firstStep ? directionOf(playerRoomId, firstStep) : undefined;
+      direction = resolved ?? "near";
+    }
+
+    signals.push({
+      hunterId: hunter.id,
+      direction,
+      distance: distance as 0 | 1 | 2,
+      texture: textureFor(hunter.state)
+    });
+  }
+
+  const contacts = hunters.filter(h => h.roomId === playerRoomId).map(h => h.id);
+
+  return { hunters, signals, contacts };
+}
+
+function textureFor(state: HunterState): string {
+  switch (state) {
+    case "hunting": return "closing in";
+    case "drawn": return "moving toward you";
+    case "roaming": return "shuffling about";
+    case "dormant": return "still";
+  }
+}

--- a/src/game/delve/lamp.ts
+++ b/src/game/delve/lamp.ts
@@ -1,0 +1,48 @@
+// The lamp is the clock (Pillar 2). Pure oil-track math: no React, no rng.
+// See docs/design/the-delve.md.
+
+import type { LampState, LightState, OilAction } from "./types";
+
+/** Oil cost per action, per the design doc. */
+export const OIL_COSTS: Record<OilAction, number> = {
+  move: 1,
+  search: 2,
+  listen: 1,
+  encounterBeat: 1,
+  disarm: 2,
+  crank: 1,
+  consultMap: 1
+};
+
+/** Light state is dim at <= 25% of capacity (and > 0), dark at 0, else bright. */
+export function getLightState(lamp: LampState): LightState {
+  if (lamp.oil <= 0) return "dark";
+  if (lamp.oil <= lamp.capacity * 0.25) return "dim";
+  return "bright";
+}
+
+/**
+ * Spend oil for an action. Oil floors at 0 rather than going negative —
+ * the sim never blocks an action for lack of oil; darkness is the penalty.
+ */
+export function spendOil(lamp: LampState, action: OilAction): LampState {
+  const cost = OIL_COSTS[action];
+  return {
+    ...lamp,
+    oil: Math.max(0, lamp.oil - cost)
+  };
+}
+
+/**
+ * Refill the lamp from a packed flask, consuming one flask and topping the
+ * oil track up to capacity. No-op (returns the same lamp) if no flasks
+ * remain.
+ */
+export function refillFromFlask(lamp: LampState): LampState {
+  if (lamp.flasksPacked <= 0) return lamp;
+  return {
+    ...lamp,
+    oil: lamp.capacity,
+    flasksPacked: lamp.flasksPacked - 1
+  };
+}

--- a/src/game/delve/noise.ts
+++ b/src/game/delve/noise.ts
@@ -1,0 +1,108 @@
+// Noise propagation over the room graph (Pillar 3). Pure, no rng.
+// See docs/design/the-delve.md.
+
+import type { LightState, NoiseEvent } from "./types";
+
+/** Room adjacency map: roomId -> ids of directly connected rooms. */
+export type RoomAdjacency = Record<string, string[]>;
+
+/** Loudness for causes with a fixed value (move is variable; see moveNoiseLoudness). */
+export const NOISE_LOUDNESS: Record<Exclude<NoiseEvent["cause"], "move" | "other">, number> = {
+  search: 2,
+  fightBeat: 3,
+  lockwork: 3,
+  flee: 4,
+  crank: 4
+};
+
+/**
+ * Move noise: base 1, +1 if the pack is over 60% capacity, +1 more if the
+ * lamp is dark.
+ */
+export function moveNoiseLoudness(params: { packRatio: number; lightState: LightState }): number {
+  let loudness = 1;
+  if (params.packRatio > 0.6) loudness += 1;
+  if (params.lightState === "dark") loudness += 1;
+  return loudness;
+}
+
+/**
+ * BFS distance from `fromRoomId` to every reachable room in the adjacency
+ * graph. The origin room has distance 0.
+ */
+export function bfsDistances(adjacency: RoomAdjacency, fromRoomId: string): Record<string, number> {
+  const distances: Record<string, number> = { [fromRoomId]: 0 };
+  const queue: string[] = [fromRoomId];
+  let head = 0;
+  while (head < queue.length) {
+    const current = queue[head]!;
+    head += 1;
+    const currentDistance = distances[current]!;
+    const neighbors = adjacency[current] ?? [];
+    for (const neighbor of neighbors) {
+      if (distances[neighbor] !== undefined) continue;
+      distances[neighbor] = currentDistance + 1;
+      queue.push(neighbor);
+    }
+  }
+  return distances;
+}
+
+/**
+ * Graph distance between two rooms, or `undefined` if unreachable.
+ */
+export function graphDistance(adjacency: RoomAdjacency, fromRoomId: string, toRoomId: string): number | undefined {
+  return bfsDistances(adjacency, fromRoomId)[toRoomId];
+}
+
+/**
+ * The full BFS shortest path from `fromRoomId` to `toRoomId`, inclusive of
+ * both endpoints, or `undefined` if unreachable.
+ */
+export function bfsPath(adjacency: RoomAdjacency, fromRoomId: string, toRoomId: string): string[] | undefined {
+  if (fromRoomId === toRoomId) return [fromRoomId];
+  const previous: Record<string, string> = {};
+  const visited = new Set<string>([fromRoomId]);
+  const queue: string[] = [fromRoomId];
+  let head = 0;
+  while (head < queue.length) {
+    const current = queue[head]!;
+    head += 1;
+    const neighbors = adjacency[current] ?? [];
+    for (const neighbor of neighbors) {
+      if (visited.has(neighbor)) continue;
+      visited.add(neighbor);
+      previous[neighbor] = current;
+      if (neighbor === toRoomId) {
+        const path = [toRoomId];
+        let node = toRoomId;
+        while (node !== fromRoomId) {
+          node = previous[node]!;
+          path.push(node);
+        }
+        return path.reverse();
+      }
+      queue.push(neighbor);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Emit a noise event. Pure passthrough today — the single point every
+ * source of noise (movement, combat, lockwork, flight, cranking) should
+ * route through, so future hooks (logging, alertness feed) have one seam.
+ */
+export function emitNoise(event: NoiseEvent): NoiseEvent {
+  return event;
+}
+
+/**
+ * Whether a hunter standing in `hunterRoomId` hears a noise: true when the
+ * noise's loudness is at least the graph distance to the hunter.
+ */
+export function hunterHears(noise: NoiseEvent, hunterRoomId: string, adjacency: RoomAdjacency): boolean {
+  const distance = graphDistance(adjacency, noise.roomId, hunterRoomId);
+  if (distance === undefined) return false;
+  return noise.loudness >= distance;
+}

--- a/src/game/delve/place.ts
+++ b/src/game/delve/place.ts
@@ -1,0 +1,217 @@
+// Place registry, validation, adjacency, and per-run population.
+// See docs/design/the-delve.md (Pillar 1) and src/game/delve/types.ts.
+
+import type { Rng } from "../rng";
+import type {
+  Place,
+  PlaceFloor,
+  PlaceRoom,
+  DelveRunState
+} from "./types";
+import { GOBLIN_WARRENS } from "./places/goblinWarrens";
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const PLACES: Record<string, Place> = {
+  [GOBLIN_WARRENS.id]: GOBLIN_WARRENS
+};
+
+export function getPlace(id: string): Place {
+  const place = PLACES[id];
+  if (!place) throw new Error(`Unknown place: ${id}`);
+  return place;
+}
+
+// ---------------------------------------------------------------------------
+// Adjacency
+// ---------------------------------------------------------------------------
+
+/** Room id -> reachable room ids, honoring oneWay exits (no reverse edge). */
+export function buildAdjacency(floor: PlaceFloor): Record<string, string[]> {
+  const adjacency: Record<string, string[]> = {};
+  for (const room of floor.rooms) {
+    adjacency[room.id] = room.exits.map(exit => exit.to);
+  }
+  return adjacency;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export function validatePlace(place: Place): void {
+  if (place.floors.length === 0) {
+    throw new Error(`Place "${place.id}" has no floors`);
+  }
+
+  for (const floor of place.floors) {
+    validateFloor(place.id, floor);
+  }
+}
+
+function validateFloor(placeId: string, floor: PlaceFloor): void {
+  const label = `${placeId} floor ${floor.floor}`;
+  const roomsById = new Map<string, PlaceRoom>(floor.rooms.map(r => [r.id, r]));
+
+  if (roomsById.size !== floor.rooms.length) {
+    throw new Error(`${label}: duplicate room ids detected`);
+  }
+
+  // A room's exits must use distinct directions — doorOverrides key on
+  // "roomId:direction", and prose navigation ("go west") is ambiguous otherwise.
+  for (const room of floor.rooms) {
+    const seenDirections = new Set<string>();
+    for (const exit of room.exits) {
+      if (seenDirections.has(exit.direction)) {
+        throw new Error(
+          `${label}: room "${room.id}" has more than one exit in direction "${exit.direction}"`
+        );
+      }
+      seenDirections.add(exit.direction);
+    }
+  }
+
+  // Every exit's `to` must exist, and reciprocal exits must exist unless oneWay.
+  for (const room of floor.rooms) {
+    for (const exit of room.exits) {
+      const target = roomsById.get(exit.to);
+      if (!target) {
+        throw new Error(
+          `${label}: room "${room.id}" has an exit (${exit.direction}) to unknown room "${exit.to}"`
+        );
+      }
+      if (!exit.oneWay) {
+        const hasReciprocal = target.exits.some(e => e.to === room.id);
+        if (!hasReciprocal) {
+          throw new Error(
+            `${label}: exit "${room.id}" -> "${exit.to}" (${exit.direction}) has no reciprocal exit ` +
+            `back from "${exit.to}"; mark it oneWay if that is intentional`
+          );
+        }
+      }
+    }
+  }
+
+  // entranceRoomId must exist.
+  if (!roomsById.has(floor.entranceRoomId)) {
+    throw new Error(`${label}: entranceRoomId "${floor.entranceRoomId}" does not exist`);
+  }
+
+  // Every extract roomId must exist.
+  for (const extract of floor.extracts) {
+    if (!roomsById.has(extract.roomId)) {
+      throw new Error(
+        `${label}: extract "${extract.id}" references unknown room "${extract.roomId}"`
+      );
+    }
+  }
+  if (floor.extracts.length === 0) {
+    throw new Error(`${label}: has no extracts defined`);
+  }
+
+  // Floor must be fully connected via BFS from the entrance (treating exits
+  // as directed edges; oneWay exits still count as forward reachability).
+  const adjacency = buildAdjacency(floor);
+  const reached = bfsReachable(floor.entranceRoomId, adjacency);
+  for (const room of floor.rooms) {
+    if (!reached.has(room.id)) {
+      throw new Error(
+        `${label}: room "${room.id}" is not reachable from entrance "${floor.entranceRoomId}"`
+      );
+    }
+  }
+
+  // hunterSpawn rooms must be at least hunterBudget.max so a full spawn roll
+  // never runs out of eligible rooms.
+  const hunterSpawnRooms = floor.rooms.filter(r => r.hunterSpawn);
+  if (hunterSpawnRooms.length < floor.hunterBudget.max) {
+    throw new Error(
+      `${label}: only ${hunterSpawnRooms.length} hunterSpawn rooms, need at least ` +
+      `hunterBudget.max (${floor.hunterBudget.max})`
+    );
+  }
+
+  // At least one extract per floor must be reachable from the entrance.
+  const reachableExtract = floor.extracts.some(e => reached.has(e.roomId));
+  if (!reachableExtract) {
+    throw new Error(`${label}: no extract is reachable from entrance "${floor.entranceRoomId}"`);
+  }
+}
+
+function bfsReachable(start: string, adjacency: Record<string, string[]>): Set<string> {
+  const visited = new Set<string>([start]);
+  const queue: string[] = [start];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    for (const next of adjacency[current] ?? []) {
+      if (!visited.has(next)) {
+        visited.add(next);
+        queue.push(next);
+      }
+    }
+  }
+  return visited;
+}
+
+// ---------------------------------------------------------------------------
+// Per-run population
+// ---------------------------------------------------------------------------
+
+export interface PopulatedFloor {
+  /** Room id -> chosen prose variant for this run. */
+  roomProse: Record<string, string>;
+  /** "roomId:direction" -> resolved door state, for exits with a doorStates pool. */
+  doorOverrides: DelveRunState["doorOverrides"];
+  /** Room ids chosen as hunter spawn points this run. */
+  hunterSpawnRoomIds: string[];
+  /** Room ids given a supply cache (oil flask or rations) this run. */
+  supplyRoomIds: Array<{ roomId: string; kind: "oilFlask" | "rations" }>;
+  /** Room ids that will roll loot this run (actual generation stays downstream). */
+  lootRoomIds: string[];
+}
+
+export interface PopulateFloorArgs {
+  floor: PlaceFloor;
+  rng: Rng;
+  tier: number;
+}
+
+export function populateFloor({ floor, rng }: PopulateFloorArgs): PopulatedFloor {
+  const roomProse: Record<string, string> = {};
+  const doorOverrides: DelveRunState["doorOverrides"] = {};
+
+  for (const room of floor.rooms) {
+    roomProse[room.id] = rng.pickOne(room.prose);
+
+    for (const exit of room.exits) {
+      if (!exit.doorStates || exit.doorStates.length === 0) continue;
+      const rolled = rng.pickOne(exit.doorStates);
+      if (rolled === "open") continue; // open = no override needed
+      const state = rolled === "lockable" ? "locked" : rolled === "jammable" ? "jammed" : "shut";
+      doorOverrides[`${room.id}:${exit.direction}`] = state;
+    }
+  }
+
+  // Hunter spawns: choose a count within [min, max], drawn from eligible rooms.
+  const eligibleHunterRooms = floor.rooms.filter(r => r.hunterSpawn).map(r => r.id);
+  const hunterCount = rng.nextInt(floor.hunterBudget.min, floor.hunterBudget.max);
+  const shuffledHunterRooms = rng.shuffle(eligibleHunterRooms);
+  const hunterSpawnRoomIds = shuffledHunterRooms.slice(0, hunterCount);
+
+  // Supply caches: 2-3 placed in supplySpawn rooms, split between oil flasks
+  // and rations.
+  const eligibleSupplyRooms = floor.rooms.filter(r => r.supplySpawn).map(r => r.id);
+  const supplyCount = Math.min(rng.nextInt(2, 3), eligibleSupplyRooms.length);
+  const shuffledSupplyRooms = rng.shuffle(eligibleSupplyRooms);
+  const supplyRoomIds = shuffledSupplyRooms.slice(0, supplyCount).map(roomId => ({
+    roomId,
+    kind: rng.pickOne(["oilFlask", "rations"] as const)
+  }));
+
+  // Loot: mark every room with a lootTableId as having loot this run.
+  const lootRoomIds = floor.rooms.filter(r => r.lootTableId).map(r => r.id);
+
+  return { roomProse, doorOverrides, hunterSpawnRoomIds, supplyRoomIds, lootRoomIds };
+}

--- a/src/game/delve/places/goblinWarrens.ts
+++ b/src/game/delve/places/goblinWarrens.ts
@@ -1,0 +1,713 @@
+// The Goblin Warrens — first authored Place for the Delve rebuild.
+// Hand-dug tunnels braced with stolen lumber, tallow smoke, cheap glass.
+// See docs/design/the-delve.md (Pillar 1) for the extract/topology contract.
+
+import type { Direction, Place, PlaceExit, PlaceFloor, PlaceRoom, SenseTag } from "../types";
+
+// ---------------------------------------------------------------------------
+// Small internal builder so reciprocal exits can't drift out of sync by hand.
+// (Local to this file — not part of the shared engine contract.)
+// ---------------------------------------------------------------------------
+
+interface RoomInit {
+  id: string;
+  name: string;
+  prose: string[];
+  landmark?: boolean;
+  lootTableId?: string;
+  hunterSpawn?: boolean;
+  supplySpawn?: boolean;
+}
+
+interface EdgeSpec {
+  from: string;
+  dir: Direction;
+  to: string;
+  /** Reverse direction back from `to`. Omit for oneWay edges. */
+  revDir?: Direction;
+  oneWay?: boolean;
+  doorStates?: PlaceExit["doorStates"];
+  senses?: SenseTag[];
+  /** Senses on the reverse exit (from `to` back toward `from`). */
+  revSenses?: SenseTag[];
+}
+
+function buildRooms(inits: RoomInit[], edges: EdgeSpec[]): PlaceRoom[] {
+  const exitsByRoom = new Map<string, PlaceExit[]>(inits.map(r => [r.id, []]));
+
+  for (const edge of edges) {
+    const forward = exitsByRoom.get(edge.from);
+    const backward = exitsByRoom.get(edge.to);
+    if (!forward || !backward) {
+      throw new Error(`goblinWarrens: edge references unknown room (${edge.from} -> ${edge.to})`);
+    }
+    forward.push({
+      direction: edge.dir,
+      to: edge.to,
+      oneWay: edge.oneWay,
+      doorStates: edge.doorStates,
+      senses: edge.senses
+    });
+    if (!edge.oneWay) {
+      if (!edge.revDir) {
+        throw new Error(`goblinWarrens: edge ${edge.from} -> ${edge.to} needs revDir unless oneWay`);
+      }
+      backward.push({
+        direction: edge.revDir,
+        to: edge.from,
+        senses: edge.revSenses
+      });
+    }
+  }
+
+  return inits.map(init => ({
+    id: init.id,
+    name: init.name,
+    prose: init.prose,
+    landmark: init.landmark,
+    lootTableId: init.lootTableId,
+    hunterSpawn: init.hunterSpawn,
+    supplySpawn: init.supplySpawn,
+    exits: exitsByRoom.get(init.id)!
+  }));
+}
+
+const LOOT = "loot_goblin_t1";
+
+// ---------------------------------------------------------------------------
+// Floor 1 — The Upper Warrens
+// ---------------------------------------------------------------------------
+
+const FLOOR1_ROOMS: RoomInit[] = [
+  {
+    id: "gullet",
+    name: "The Gullet",
+    landmark: true,
+    prose: [
+      "The tunnel mouth you came in through, ribs of stolen timber holding back the dark.",
+      "Cold surface air still clings here, thinning fast the deeper you look."
+    ]
+  },
+  {
+    id: "antechamber",
+    name: "Antechamber",
+    prose: [
+      "A low crawl-space, walls slick where hands have braced against them for years.",
+      "Someone has scratched tally marks into the timber, over and over, never finishing a set."
+    ]
+  },
+  {
+    id: "midden_hollow",
+    name: "Midden Hollow",
+    prose: [
+      "A refuse pit gone half solid, bones and rind pressed into a black crust.",
+      "Flies that should be dead in this cold still circle over something soft."
+    ]
+  },
+  {
+    id: "bramble_lock",
+    name: "Bramble Lock",
+    prose: [
+      "A door of lashed thornwood, meant to bloody hands that don't know the trick of it.",
+      "Dried bramble laced through an iron ring, more warning than wall."
+    ],
+    lootTableId: LOOT
+  },
+  {
+    id: "tallow_gallery",
+    name: "The Tallow Gallery",
+    landmark: true,
+    prose: [
+      "A wide gallery lit by a hundred guttering tallow stubs pressed into the walls.",
+      "The grease-smoke here is thick enough to taste, and every surface is filmed with it."
+    ]
+  },
+  {
+    id: "candle_row",
+    name: "Candle Row",
+    prose: [
+      "A ledge lined with stolen candlesticks, most of them melted down to stubs.",
+      "Wax has pooled and hardened into a second floor beneath your boots."
+    ]
+  },
+  {
+    id: "grease_cellar",
+    name: "Grease Cellar",
+    prose: [
+      "Barrels of rendered fat, some split and gone rancid, sweat in the warm dark.",
+      "The floor here is treacherous, a skin of old grease over old grease."
+    ]
+  },
+  {
+    id: "trade_room",
+    name: "Trade Room",
+    prose: [
+      "A slumping floor and a low table piled with things traded, stolen, or both.",
+      "Someone keeps a ledger here in charcoal, tally marks for debts no one will pay."
+    ],
+    lootTableId: LOOT,
+    supplySpawn: true
+  },
+  {
+    id: "weavers_nook",
+    name: "Weaver's Nook",
+    prose: [
+      "A nesting tunnel piled with stolen blankets, still holding someone's shape.",
+      "Bundles of coarse thread hang from pegs driven straight into the rock."
+    ],
+    supplySpawn: true
+  },
+  {
+    id: "kennel_row",
+    name: "Kennel Row",
+    prose: [
+      "A row of low pens, chains still fixed to the wall, whatever they held now loose.",
+      "The straw here is fresh. Something is still using this room."
+    ],
+    hunterSpawn: true
+  },
+  {
+    id: "bone_pile_den",
+    name: "Bone Pile Den",
+    prose: [
+      "A den built around a pile of picked bones, arranged with something like pride.",
+      "Trophies, mostly small. A few are not."
+    ],
+    hunterSpawn: true
+  },
+  {
+    id: "snare_hall",
+    name: "Snare Hall",
+    prose: [
+      "A narrow hall strung with tripwire at ankle height, more nuisance than danger.",
+      "Bells of scrap tin hang from the wire, silent only because nothing has passed through lately."
+    ],
+    hunterSpawn: true
+  },
+  {
+    id: "toll_bridge",
+    name: "The Toll Bridge",
+    landmark: true,
+    hunterSpawn: true,
+    prose: [
+      "A plank bridge over a black drop, wide enough for one, guarded by habit if not always by goblins.",
+      "The planks bow underfoot. Whatever's below the bridge, you'd rather not meet it on the way down."
+    ]
+  },
+  {
+    id: "sleepers_court",
+    name: "Sleeper's Court",
+    landmark: true,
+    hunterSpawn: true,
+    prose: [
+      "A wide, low court packed with sleeping-nests, a dozen at least, most of them still warm.",
+      "The air here is thick with breath and tallow smoke. Nothing is sleeping when you're loud."
+    ],
+    lootTableId: LOOT
+  },
+  {
+    id: "gnaw_pit",
+    name: "Gnaw Pit",
+    prose: [
+      "A sunken pit ringed with gnaw-marks in the stone itself, patient and old.",
+      "Something has been working at the rock here for longer than makes sense."
+    ],
+    hunterSpawn: true
+  },
+  {
+    id: "glass_gallery",
+    name: "The Glass Gallery",
+    landmark: true,
+    prose: [
+      "A chiseled gallery glittering with cheap glass, hammered into the walls like a hoard of stars.",
+      "Every color of bottle glass, worthless and beautiful, catching what little light you carry."
+    ],
+    lootTableId: LOOT
+  },
+  {
+    id: "side_larder",
+    name: "Side Larder",
+    prose: [
+      "A larder hung with smoked things you cannot quite name.",
+      "Strips of dried meat sway on hooks, and something in the corner is still curing."
+    ],
+    supplySpawn: true
+  },
+  {
+    id: "chute_mouth",
+    name: "Chute Mouth",
+    prose: [
+      "A worn hole in the floor, smoothed by generations of goblins taking the fast way down.",
+      "The drop below is short enough to survive and loud enough to regret."
+    ]
+  },
+  {
+    id: "under_chute",
+    name: "Under the Chute",
+    hunterSpawn: true,
+    prose: [
+      "Where the chute lets out, a heap of old bedding softening the landing.",
+      "The floor here is worn concave from things landing exactly where you just did."
+    ]
+  },
+  {
+    id: "collapsing_squeeze",
+    name: "Collapsing Squeeze",
+    prose: [
+      "A crack in the rock, widened by tools and time, groaning faintly as you consider it.",
+      "Loose stone rattles somewhere above. This passage will not be here forever."
+    ]
+  },
+  {
+    id: "squeeze_exit",
+    name: "Squeeze's End",
+    prose: [
+      "Where the squeeze spits you out, dust still sifting down behind you.",
+      "You can't see the way back. The passage behind has already half-closed."
+    ]
+  },
+  {
+    id: "deep_gallery",
+    name: "Deep Gallery",
+    hunterSpawn: true,
+    prose: [
+      "A long gallery where the ceiling drops low and the air turns cold and wet.",
+      "Water sound carries from somewhere close, though nothing here is flooded yet."
+    ]
+  },
+  {
+    id: "flooded_approach",
+    name: "Flooded Approach",
+    supplySpawn: true,
+    prose: [
+      "The floor slopes down toward standing water, black and perfectly still.",
+      "Old waterlines stain the walls well above your head."
+    ]
+  },
+  {
+    id: "flooded_stair",
+    name: "The Flooded Stair",
+    landmark: true,
+    prose: [
+      "A stairwell half-drowned, current only when the water is moving toward the surface.",
+      "The water here rises and falls on its own clock, not yours."
+    ]
+  },
+  {
+    id: "winch_approach",
+    name: "Winch Approach",
+    prose: [
+      "A short hall of straining rope, all leading toward one groaning mechanism.",
+      "The smell of old rope oil is stronger here than anything goblin-made."
+    ]
+  },
+  {
+    id: "rope_winch",
+    name: "The Rope Winch",
+    landmark: true,
+    prose: [
+      "A crude winch bolted into the rock, hauling a cage up toward a surface shaft.",
+      "Someone built this to move plunder out quietly. It has never once been quiet."
+    ]
+  },
+  {
+    id: "damp_cutback",
+    name: "Damp Cutback",
+    hunterSpawn: true,
+    prose: [
+      "A low cut doubling back on itself, damp enough that moss has taken the walls.",
+      "The passage bends hard here, easy to lose your bearings in the dark."
+    ]
+  }
+];
+
+const FLOOR1_EDGES: EdgeSpec[] = [
+  { from: "gullet", dir: "south", to: "antechamber", revDir: "north" },
+  { from: "antechamber", dir: "east", to: "midden_hollow", revDir: "west" },
+  { from: "antechamber", dir: "south", to: "tallow_gallery", revDir: "north" },
+  { from: "midden_hollow", dir: "south", to: "bramble_lock", revDir: "north",
+    doorStates: ["open", "lockable", "jammable"] },
+  { from: "bramble_lock", dir: "east", to: "tallow_gallery", revDir: "west" },
+  { from: "tallow_gallery", dir: "east", to: "candle_row", revDir: "west" },
+  { from: "tallow_gallery", dir: "south", to: "grease_cellar", revDir: "north" },
+  { from: "tallow_gallery", dir: "down", to: "toll_bridge", revDir: "up",
+    doorStates: ["open", "jammable"], senses: ["chittering"] },
+  { from: "tallow_gallery", dir: "up", to: "weavers_nook", revDir: "down" },
+  { from: "candle_row", dir: "north", to: "trade_room", revDir: "south" },
+  { from: "candle_row", dir: "south", to: "grease_cellar", revDir: "east" },
+  { from: "candle_row", dir: "down", to: "weavers_nook", revDir: "up" },
+  { from: "grease_cellar", dir: "down", to: "kennel_row", revDir: "up", senses: ["greaseSmell"] },
+  { from: "kennel_row", dir: "east", to: "bone_pile_den", revDir: "west" },
+  { from: "bone_pile_den", dir: "south", to: "snare_hall", revDir: "north" },
+  { from: "bone_pile_den", dir: "down", to: "collapsing_squeeze", revDir: "up",
+    senses: ["narrowSqueeze"] },
+  { from: "snare_hall", dir: "south", to: "sleepers_court", revDir: "north",
+    senses: ["tallow", "chittering"] },
+  { from: "toll_bridge", dir: "east", to: "sleepers_court", revDir: "west",
+    senses: ["tallow", "chittering"] },
+  { from: "sleepers_court", dir: "down", to: "gnaw_pit", revDir: "up" },
+  { from: "sleepers_court", dir: "south", to: "chute_mouth", revDir: "north" },
+  { from: "chute_mouth", dir: "down", to: "under_chute", oneWay: true, senses: ["narrowSqueeze"] },
+  { from: "collapsing_squeeze", dir: "down", to: "squeeze_exit", oneWay: true,
+    senses: ["narrowSqueeze"] },
+  { from: "gnaw_pit", dir: "south", to: "deep_gallery", revDir: "north" },
+  { from: "under_chute", dir: "east", to: "deep_gallery", revDir: "west" },
+  { from: "deep_gallery", dir: "east", to: "flooded_approach", revDir: "west",
+    senses: ["waterSound", "coldDraft"] },
+  { from: "flooded_approach", dir: "down", to: "flooded_stair", revDir: "up",
+    doorStates: ["open", "jammable"], senses: ["waterSound", "coldDraft"] },
+  { from: "deep_gallery", dir: "south", to: "winch_approach", revDir: "north" },
+  { from: "winch_approach", dir: "down", to: "rope_winch", revDir: "up", senses: ["coldDraft"] },
+  { from: "squeeze_exit", dir: "east", to: "winch_approach", revDir: "west" },
+  { from: "weavers_nook", dir: "south", to: "side_larder", revDir: "north" },
+  { from: "side_larder", dir: "east", to: "glass_gallery", revDir: "west" },
+  { from: "glass_gallery", dir: "south", to: "damp_cutback", revDir: "north", senses: ["lightBeyond"] },
+  { from: "damp_cutback", dir: "east", to: "deep_gallery", revDir: "down" }
+];
+
+const FLOOR1: PlaceFloor = {
+  floor: 1,
+  entranceRoomId: "gullet",
+  rooms: buildRooms(FLOOR1_ROOMS, FLOOR1_EDGES),
+  extracts: [
+    {
+      id: "f1_barred_door",
+      roomId: "gullet",
+      label: "The way you came",
+      condition: "closesAtAlertness",
+      alertnessLevel: 3
+    },
+    {
+      id: "f1_flooded_stair",
+      roomId: "flooded_stair",
+      label: "The flooded stair",
+      condition: "waterClock"
+    },
+    {
+      id: "f1_rope_winch",
+      roomId: "rope_winch",
+      label: "The rope winch",
+      condition: "cranked",
+      cranksRequired: 3
+    }
+  ],
+  hunterBudget: { min: 4, max: 6 }
+};
+
+// ---------------------------------------------------------------------------
+// Floor 2 — The Deep Warrens
+// ---------------------------------------------------------------------------
+
+const FLOOR2_ROOMS: RoomInit[] = [
+  {
+    id: "bonefire_hall",
+    name: "Bonefire Hall",
+    landmark: true,
+    prose: [
+      "The stair down from the upper warrens opens onto a hall scorched black by old fires.",
+      "Bone ash is banked in drifts against the walls, still faintly warm underfoot."
+    ]
+  },
+  {
+    id: "ash_passage",
+    name: "Ash Passage",
+    prose: [
+      "A low passage floored in fine grey ash that rises with every step.",
+      "Footprints in the ash go one direction only, and it isn't yours."
+    ]
+  },
+  {
+    id: "root_hollow",
+    name: "Root Hollow",
+    prose: [
+      "Pale roots have broken through here, thick as arms, groping toward nothing.",
+      "The hollow smells of wet earth beneath the ash and grease."
+    ]
+  },
+  {
+    id: "sunken_door",
+    name: "Sunken Door",
+    prose: [
+      "A door set below the floor line, warped by years of standing damp.",
+      "Whatever this once guarded, the goblins have long since carried it off."
+    ],
+    lootTableId: LOOT
+  },
+  {
+    id: "longhouse",
+    name: "The Longhouse",
+    landmark: true,
+    prose: [
+      "A long hall raised on stolen roof-beams, the closest thing this warren has to a throne room.",
+      "Trophies and rags of banners hang from the beams, all of it slightly too large for goblins."
+    ]
+  },
+  {
+    id: "trophy_nook",
+    name: "The Trophy Nook",
+    landmark: true,
+    prose: [
+      "A shallow nook crowded with things too fine for a warren — armor, blades, a single boot.",
+      "Everything here was taken from someone who is almost certainly dead."
+    ],
+    lootTableId: LOOT
+  },
+  {
+    id: "grinding_room",
+    name: "Grinding Room",
+    prose: [
+      "A crude whetstone turns slowly on a treadle, worn smooth by goblin hands.",
+      "The floor is gritty with metal dust and a little dried blood."
+    ]
+  },
+  {
+    id: "stores_vault",
+    name: "Stores Vault",
+    supplySpawn: true,
+    prose: [
+      "Sacks and jars stacked with more order than anything else in this warren.",
+      "Someone here understands that hunger is worse than any trap."
+    ]
+  },
+  {
+    id: "tanners_nook",
+    name: "Tanner's Nook",
+    supplySpawn: true,
+    prose: [
+      "Hides stretched on frames, the smell of curing leather sharp enough to sting.",
+      "Racks of half-finished armor lean against a wall slick with old fat."
+    ]
+  },
+  {
+    id: "gnawed_stair",
+    name: "Gnawed Stair",
+    hunterSpawn: true,
+    prose: [
+      "A narrow stair, its wooden edges gnawed soft by things with better teeth than sense.",
+      "Every step down is a little louder than the last."
+    ]
+  },
+  {
+    id: "skull_shrine",
+    name: "Skull Shrine",
+    hunterSpawn: true,
+    prose: [
+      "A shrine of stacked skulls, none of them goblin, arranged with reverence you didn't expect.",
+      "Tallow candles gutter at the shrine's base, always freshly lit."
+    ]
+  },
+  {
+    id: "rat_run",
+    name: "Rat Run",
+    hunterSpawn: true,
+    prose: [
+      "A cramped tunnel shared, unwillingly, with a great many rats.",
+      "The rats scatter ahead of you, which is its own kind of warning to whatever's further in."
+    ]
+  },
+  {
+    id: "longhouse_doors",
+    name: "Longhouse Doors",
+    landmark: true,
+    hunterSpawn: true,
+    prose: [
+      "Two heavy doors banded in scavenged iron, the closest thing to a real chokepoint down here.",
+      "Whoever stands watch here means to be the last thing you see."
+    ]
+  },
+  {
+    id: "chieftains_den",
+    name: "The Chieftain's Den",
+    landmark: true,
+    hunterSpawn: true,
+    prose: [
+      "A wide den heaped with furs and stolen finery, clearly the seat of something in charge.",
+      "The air here is thick with tallow smoke, sweat, and old smoke."
+    ],
+    lootTableId: LOOT
+  },
+  {
+    id: "midden_drop",
+    name: "Midden Drop",
+    hunterSpawn: true,
+    prose: [
+      "A refuse chute dropping from the den above, spilling into a pit of old bones and rot.",
+      "Things get thrown away down here. Not all of it stays thrown away."
+    ]
+  },
+  {
+    id: "sump_cistern",
+    name: "The Sump Cistern",
+    landmark: true,
+    prose: [
+      "A cracked cistern, its water black and faintly moving, though nothing should be stirring it.",
+      "The sound of dripping water is constant here, and slightly too rhythmic."
+    ]
+  },
+  {
+    id: "tallow_stores",
+    name: "Tallow Stores",
+    supplySpawn: true,
+    prose: [
+      "Shelves of rendered tallow blocks, waiting to become candles or worse.",
+      "The smell here is thick enough to coat the back of your throat."
+    ]
+  },
+  {
+    id: "ash_chute_mouth",
+    name: "Ash Chute Mouth",
+    prose: [
+      "A steep, ash-choked slide leading down from the den, used when the front door isn't an option.",
+      "The chieftain's own bolt-hole, judging by the state of the handholds."
+    ]
+  },
+  {
+    id: "under_ash_chute",
+    name: "Under the Ash Chute",
+    hunterSpawn: true,
+    prose: [
+      "Where the chute empties out, ash banked deep enough to swallow the sound of landing.",
+      "You come up coughing, grey to the knees, in a room that clearly expects visitors this way."
+    ]
+  },
+  {
+    id: "collapsed_squeeze",
+    name: "Collapsed Squeeze",
+    prose: [
+      "A passage half caved in, the gap just wide enough if you don't think about it too hard.",
+      "Stone shifts somewhere close by. This will not stay passable."
+    ]
+  },
+  {
+    id: "squeeze_end",
+    name: "Squeeze's Far End",
+    prose: [
+      "You come through into open space, dust and grit sifting down behind you.",
+      "The way back is gone, or close enough to it. There's only forward now."
+    ]
+  },
+  {
+    id: "lower_gallery",
+    name: "Lower Gallery",
+    hunterSpawn: true,
+    prose: [
+      "A broad, low gallery where the warren finally starts to feel older than the goblins in it.",
+      "The walls here bear marks no goblin tool made."
+    ]
+  },
+  {
+    id: "postern_approach",
+    name: "Postern Approach",
+    supplySpawn: true,
+    prose: [
+      "A narrow hall leading to a door that was clearly meant for someone to leave quietly by.",
+      "Cold air draws steadily from ahead, the first clean air in a long while."
+    ]
+  },
+  {
+    id: "postern_stair",
+    name: "The Postern Stair",
+    landmark: true,
+    prose: [
+      "A tight, iron-barred stair the chieftain keeps for a fast, quiet way out.",
+      "The bar on this door is new. Someone expects to need it in a hurry."
+    ]
+  },
+  {
+    id: "flue_approach",
+    name: "Flue Approach",
+    prose: [
+      "A crooked passage climbing gently toward a draft that smells of open sky.",
+      "Old soot streaks the walls, though nothing has burned here in a long time."
+    ]
+  },
+  {
+    id: "old_flue",
+    name: "The Old Flue",
+    landmark: true,
+    prose: [
+      "A forgotten chimney flue, wide enough to climb, letting in a thread of grey daylight.",
+      "Whoever dug this warren left themselves a way out no goblin remembers."
+    ]
+  },
+  {
+    id: "damp_hollow",
+    name: "Damp Hollow",
+    hunterSpawn: true,
+    prose: [
+      "A low, wet hollow where the cistern's overflow has carved a shallow basin.",
+      "Moss softens every sound here, which cuts both ways."
+    ]
+  }
+];
+
+const FLOOR2_EDGES: EdgeSpec[] = [
+  { from: "bonefire_hall", dir: "down", to: "ash_passage", revDir: "up" },
+  { from: "ash_passage", dir: "east", to: "root_hollow", revDir: "west" },
+  { from: "ash_passage", dir: "south", to: "longhouse", revDir: "north" },
+  { from: "root_hollow", dir: "south", to: "sunken_door", revDir: "north" },
+  { from: "sunken_door", dir: "east", to: "longhouse", revDir: "west" },
+  { from: "longhouse", dir: "east", to: "trophy_nook", revDir: "west" },
+  { from: "longhouse", dir: "south", to: "grinding_room", revDir: "north" },
+  { from: "longhouse", dir: "down", to: "longhouse_doors", revDir: "up",
+    doorStates: ["open", "jammable"], senses: ["chittering"] },
+  { from: "longhouse", dir: "up", to: "tanners_nook", revDir: "down" },
+  { from: "trophy_nook", dir: "north", to: "stores_vault", revDir: "south" },
+  { from: "trophy_nook", dir: "south", to: "grinding_room", revDir: "west" },
+  { from: "tanners_nook", dir: "south", to: "sump_cistern", revDir: "north", senses: ["waterSound"] },
+  { from: "sump_cistern", dir: "west", to: "tallow_stores", revDir: "east", senses: ["tallow"] },
+  { from: "tallow_stores", dir: "south", to: "damp_hollow", revDir: "north" },
+  { from: "damp_hollow", dir: "south", to: "lower_gallery", revDir: "north" },
+  { from: "grinding_room", dir: "down", to: "gnawed_stair", revDir: "up" },
+  { from: "gnawed_stair", dir: "south", to: "skull_shrine", revDir: "north" },
+  { from: "skull_shrine", dir: "east", to: "rat_run", revDir: "west" },
+  { from: "skull_shrine", dir: "down", to: "collapsed_squeeze", revDir: "up",
+    senses: ["narrowSqueeze"] },
+  { from: "collapsed_squeeze", dir: "down", to: "squeeze_end", oneWay: true,
+    senses: ["narrowSqueeze"] },
+  { from: "squeeze_end", dir: "east", to: "postern_approach", revDir: "west", senses: ["coldDraft"] },
+  { from: "rat_run", dir: "south", to: "chieftains_den", revDir: "north",
+    senses: ["tallow", "chittering"] },
+  { from: "longhouse_doors", dir: "down", to: "chieftains_den", revDir: "up",
+    senses: ["tallow", "chittering"] },
+  { from: "chieftains_den", dir: "south", to: "midden_drop", revDir: "north" },
+  { from: "chieftains_den", dir: "down", to: "ash_chute_mouth", revDir: "up", senses: ["narrowSqueeze"] },
+  { from: "ash_chute_mouth", dir: "down", to: "under_ash_chute", oneWay: true },
+  { from: "under_ash_chute", dir: "east", to: "lower_gallery", revDir: "west" },
+  { from: "midden_drop", dir: "down", to: "lower_gallery", revDir: "up" },
+  { from: "postern_approach", dir: "down", to: "postern_stair", revDir: "up",
+    doorStates: ["open", "lockable"], senses: ["coldDraft"] },
+  { from: "lower_gallery", dir: "east", to: "flue_approach", revDir: "west" },
+  { from: "flue_approach", dir: "up", to: "old_flue", revDir: "down", senses: ["coldDraft", "lightBeyond"] }
+];
+
+const FLOOR2: PlaceFloor = {
+  floor: 2,
+  entranceRoomId: "bonefire_hall",
+  rooms: buildRooms(FLOOR2_ROOMS, FLOOR2_EDGES),
+  extracts: [
+    {
+      id: "f2_postern_stair",
+      roomId: "postern_stair",
+      label: "The postern stair",
+      condition: "closesAtAlertness",
+      alertnessLevel: 2
+    },
+    {
+      id: "f2_old_flue",
+      roomId: "old_flue",
+      label: "The old flue",
+      condition: "alwaysOpen"
+    }
+  ],
+  hunterBudget: { min: 4, max: 6 }
+};
+
+// ---------------------------------------------------------------------------
+
+export const GOBLIN_WARRENS: Place = {
+  id: "goblinWarrens",
+  name: "The Goblin Warrens",
+  biome: "goblinWarrens",
+  floors: [FLOOR1, FLOOR2]
+};

--- a/src/game/delve/types.ts
+++ b/src/game/delve/types.ts
@@ -141,6 +141,8 @@ export interface EncounterBeatResult {
   playerHpDelta: number;
   enemyHpDelta: number;
   noise: NoiseEvent;
+  /** Oil the run layer must spend for this beat/option resolution. */
+  oilAction: OilAction;
   over: boolean;
   outcome?: "won" | "escaped" | "dead";
 }

--- a/src/game/delve/types.ts
+++ b/src/game/delve/types.ts
@@ -2,7 +2,7 @@
 // See docs/design/the-delve.md. These types are the interface between the
 // engine core (lamp/noise/hunters/delveRun), authored place data, and the UI.
 
-import type { ItemInstance } from "../types";
+import type { Character, ItemInstance } from "../types";
 
 // ---------------------------------------------------------------------------
 // Places (authored, fixed layouts)
@@ -161,11 +161,27 @@ export interface ActiveEncounter {
 // The run
 // ---------------------------------------------------------------------------
 
+export type DelveRunStatus = "active" | "extracted" | "dead";
+
+/** A supply cache placed by per-run population; `found` flips when searched. */
+export interface DelveSupplyCache {
+  roomId: string;
+  kind: "oilFlask" | "rations";
+  found: boolean;
+}
+
 export interface DelveRunState {
   placeId: string;
   floor: number;
   seed: string;
+  /** Depth tier fed to loot generation (mirrors the v0.4 dungeon tier). */
+  tier: number;
+  status: DelveRunStatus;
+  /** Monotone counter; every applyDelveAction call increments it. Seeds the per-action rng. */
+  actionCount: number;
   currentRoomId: string;
+  /** The room the player was in before the current one (fall-back target). */
+  cameFromRoomId?: string;
   visitedRoomIds: string[];
   lamp: LampState;
   hunters: Hunter[];
@@ -175,6 +191,13 @@ export interface DelveRunState {
   cranksDone: Record<string, number>; // extractId -> cranks so far
   /** Per-run population results. */
   doorOverrides: Record<string, "shut" | "locked" | "jammed">; // "roomId:direction"
+  /** Room id -> prose variant chosen for this run. */
+  roomProse: Record<string, string>;
+  /** Rooms that will roll loot when searched this run. */
+  lootRoomIds: string[];
+  /** Rooms already searched this run (searching twice finds nothing new). */
+  searchedRoomIds: string[];
+  supplyCaches: DelveSupplyCache[];
   pendingLoot: Record<string, { items: ItemInstance[]; gold: number; materials: Record<string, number> }>;
   activeEncounter?: ActiveEncounter;
   hasMapItem: boolean;
@@ -183,6 +206,60 @@ export interface DelveRunState {
 
 export interface DelveNarrativeEntry {
   id: string;
-  kind: "room" | "sense" | "action" | "encounter" | "system";
+  kind: "room" | "sense" | "action" | "encounter" | "system" | "map";
   text: string;
+}
+
+// ---------------------------------------------------------------------------
+// Run actions (the pure reducer's input/output contract)
+// ---------------------------------------------------------------------------
+
+export type DelveAction =
+  | { type: "move"; direction: Direction }
+  | { type: "search" }
+  | { type: "listen" }
+  | { type: "takeLoot"; itemInstanceId?: string }
+  | { type: "takeAllLoot" }
+  | { type: "leaveLoot" }
+  | { type: "refillLamp" }
+  | { type: "consultMap" }
+  | { type: "encounterOption"; kind: EncounterOptionKind }
+  | { type: "fightBeat"; stance: FightStance }
+  | { type: "crank"; extractId: string }
+  | { type: "extract"; extractId: string }
+  | { type: "descend"; stairRoomId: string };
+
+/**
+ * Everything the run engine needs from outside its own state. Character
+ * stats/hp/inventory live in the store; the engine reads this snapshot and
+ * returns hp/inventory changes as events for the store to apply. The caller
+ * must keep the snapshot current between actions (apply hpDelta etc.).
+ */
+export interface DelveRunDeps {
+  character: Character;
+  /** Raid pack contents (for pack ratio, rations, etc.). */
+  carriedItems: ItemInstance[];
+  carriedWeight: number;
+  carryCapacity: number;
+}
+
+/** Things the outer game must react to; the engine never touches them itself. */
+export type DelveRunEvent =
+  | { kind: "extracted"; extractId: string }
+  | { kind: "died" }
+  | { kind: "descended"; floor: number }
+  | { kind: "lootFound"; roomId: string }
+  | { kind: "hpDelta"; amount: number }
+  | { kind: "enemyDefeated"; hunterId: string; enemyId: string }
+  | { kind: "reinforcement"; hunterId: string; roomId: string }
+  | { kind: "itemsTaken"; roomId: string; items: ItemInstance[]; gold: number; materials: Record<string, number> }
+  | { kind: "itemConsumed"; tag: string }
+  | { kind: "flaskConsumed" }
+  | { kind: "alertnessLevel"; level: number };
+
+export interface DelveActionResult {
+  state: DelveRunState;
+  /** Only the entries this action appended (state.narrative has the full log). */
+  narrative: DelveNarrativeEntry[];
+  events: DelveRunEvent[];
 }

--- a/src/game/delve/types.ts
+++ b/src/game/delve/types.ts
@@ -1,0 +1,186 @@
+// Shared contracts for the Delve run engine (v0.5 rebuild).
+// See docs/design/the-delve.md. These types are the interface between the
+// engine core (lamp/noise/hunters/delveRun), authored place data, and the UI.
+
+import type { ItemInstance } from "../types";
+
+// ---------------------------------------------------------------------------
+// Places (authored, fixed layouts)
+// ---------------------------------------------------------------------------
+
+export type Direction = "north" | "east" | "south" | "west" | "up" | "down";
+
+/** Sensory tag rendered as prose on an exit line ("warm air, tallow smell"). */
+export type SenseTag =
+  | "tallow" | "warmAir" | "coldDraft" | "waterSound" | "greaseSmell"
+  | "rotSmell" | "silence" | "chittering" | "lightBeyond" | "narrowSqueeze";
+
+export interface PlaceExit {
+  direction: Direction;
+  to: string; // room id
+  /** One-way exits (drops, chutes) cannot be traversed backwards. */
+  oneWay?: boolean;
+  /** Pool the per-run population draws from; omitted = always open. */
+  doorStates?: Array<"open" | "shut" | "lockable" | "jammable">;
+  senses?: SenseTag[];
+}
+
+export interface PlaceRoom {
+  id: string;
+  name: string;
+  /** Prose variants; population picks one per run. */
+  prose: string[];
+  landmark?: boolean;
+  exits: PlaceExit[];
+  /** Loot table id from the existing loot system; omitted = no loot spawn. */
+  lootTableId?: string;
+  /** Eligible hunter spawn point. */
+  hunterSpawn?: boolean;
+  /** Eligible supply cache location (oil, rations). */
+  supplySpawn?: boolean;
+}
+
+export type ExtractConditionKind =
+  | "alwaysOpen"
+  | "closesAtAlertness" // closes when alertness >= level
+  | "waterClock"        // open only while run.waterClock > 0
+  | "cranked";          // requires `cranksRequired` crank actions, each loud
+
+export interface PlaceExtract {
+  id: string;
+  roomId: string;
+  label: string;
+  condition: ExtractConditionKind;
+  /** For closesAtAlertness. */
+  alertnessLevel?: number;
+  /** For cranked. */
+  cranksRequired?: number;
+}
+
+export interface Place {
+  id: string;
+  name: string;
+  /** Biome id linking to existing bestiary/loot voice. */
+  biome: string;
+  floors: PlaceFloor[];
+}
+
+export interface PlaceFloor {
+  floor: number;
+  entranceRoomId: string;
+  rooms: PlaceRoom[];
+  extracts: PlaceExtract[];
+  /** Room count the validator asserts (guards against authoring slips). */
+  hunterBudget: { min: number; max: number };
+}
+
+// ---------------------------------------------------------------------------
+// Lamp
+// ---------------------------------------------------------------------------
+
+export type LightState = "bright" | "dim" | "dark";
+
+export interface LampState {
+  oil: number;        // current units
+  capacity: number;   // default 20
+  flasksPacked: number; // refills carried (each weight 2 in pack)
+}
+
+export type OilAction =
+  | "move" | "search" | "listen" | "encounterBeat" | "disarm"
+  | "crank" | "consultMap";
+
+// ---------------------------------------------------------------------------
+// Noise & hunters
+// ---------------------------------------------------------------------------
+
+export interface NoiseEvent {
+  roomId: string;
+  loudness: number; // hunter hears if loudness >= graph distance to it
+  cause: "move" | "search" | "fightBeat" | "lockwork" | "flee" | "crank" | "other";
+}
+
+export type HunterState = "dormant" | "roaming" | "drawn" | "hunting";
+
+export interface Hunter {
+  id: string;
+  enemyId: string;    // existing bestiary id
+  roomId: string;
+  state: HunterState;
+  /** Room id of the last noise it heard (drawn state target). */
+  heardAt?: string;
+}
+
+/** What the player perceives after a tick; rendered as directional prose. */
+export interface HunterSignal {
+  hunterId: string;
+  direction: Direction | "here" | "near";
+  distance: 0 | 1 | 2;
+  /** e.g. "dragging", "chittering" — derived from enemy definition tags. */
+  texture: string;
+}
+
+// ---------------------------------------------------------------------------
+// Encounters (inline, beat-based)
+// ---------------------------------------------------------------------------
+
+export type EncounterOptionKind =
+  | "fight" | "slipPast" | "fallBack" | "parley" | "throwRations" | "lure";
+
+export interface EncounterOption {
+  kind: EncounterOptionKind;
+  label: string;       // diegetic, e.g. "Slip along the far wall"
+  available: boolean;
+  unavailableReason?: string; // e.g. "Too heavy", "No light to slip by"
+}
+
+export type FightStance = "press" | "guard" | "breakAway";
+
+export interface EncounterBeatResult {
+  prose: string[];          // narrative lines for the column
+  playerHpDelta: number;
+  enemyHpDelta: number;
+  noise: NoiseEvent;
+  over: boolean;
+  outcome?: "won" | "escaped" | "dead";
+}
+
+export interface ActiveEncounter {
+  hunterId: string;
+  enemyId: string;
+  enemyHp: number;
+  enemyMaxHp: number;
+  beat: number;             // 1-based
+  options: EncounterOption[];
+  log: string[];
+}
+
+// ---------------------------------------------------------------------------
+// The run
+// ---------------------------------------------------------------------------
+
+export interface DelveRunState {
+  placeId: string;
+  floor: number;
+  seed: string;
+  currentRoomId: string;
+  visitedRoomIds: string[];
+  lamp: LampState;
+  hunters: Hunter[];
+  /** Alertness points; levels reuse THREAT_RULES thresholds. */
+  alertness: number;
+  waterClock: number; // actions remaining before the flooded stair closes
+  cranksDone: Record<string, number>; // extractId -> cranks so far
+  /** Per-run population results. */
+  doorOverrides: Record<string, "shut" | "locked" | "jammed">; // "roomId:direction"
+  pendingLoot: Record<string, { items: ItemInstance[]; gold: number; materials: Record<string, number> }>;
+  activeEncounter?: ActiveEncounter;
+  hasMapItem: boolean;
+  narrative: DelveNarrativeEntry[];
+}
+
+export interface DelveNarrativeEntry {
+  id: string;
+  kind: "room" | "sense" | "action" | "encounter" | "system";
+  text: string;
+}

--- a/src/game/save.ts
+++ b/src/game/save.ts
@@ -105,7 +105,10 @@ export function migrateSaveIfNeeded(state: unknown): GameState | null {
     settings: {
       ...base.settings,
       ...(isRecord(state.settings) ? state.settings : {})
-    }
+    },
+    delveRun: normalizeDelveRun(state.delveRun),
+    delveRaidPack: normalizeInventory(state.delveRaidPack) ?? undefined,
+    delveMeta: normalizeDelveMeta(state.delveMeta)
   } as GameState;
 
   return normalized;
@@ -322,6 +325,33 @@ function legacyStableExtraction(): ExtractionPoint {
     description: "A safe route leads back to the surface.",
     activationText: "You leave the dungeon with your spoils.",
     successText: "You escaped."
+  };
+}
+
+/**
+ * The Delve (v0.5) is additive and optional on GameState; we don't deep-
+ * validate its full shape (a heavily-nested pure-engine type) here — only
+ * enough of a sanity check that a corrupt/foreign value can't wrongly route
+ * the app to the delve screen on load. A malformed delve run is simply
+ * dropped, same as any other unrecognized save fragment.
+ */
+function normalizeDelveRun(value: unknown): GameState["delveRun"] {
+  if (!isRecord(value)) return undefined;
+  if (typeof value.placeId !== "string") return undefined;
+  if (typeof value.currentRoomId !== "string") return undefined;
+  if (value.status !== "active" && value.status !== "extracted" && value.status !== "dead") return undefined;
+  if (!Array.isArray(value.narrative)) return undefined;
+  return value as unknown as GameState["delveRun"];
+}
+
+function normalizeDelveMeta(value: unknown): GameState["delveMeta"] {
+  if (!isRecord(value)) return undefined;
+  if (typeof value.startedAt !== "number") return undefined;
+  return {
+    startedAt: value.startedAt,
+    xpGained: typeof value.xpGained === "number" ? value.xpGained : 0,
+    keepsakeInstanceId: typeof value.keepsakeInstanceId === "string" ? value.keepsakeInstanceId : undefined,
+    insuredInstanceId: typeof value.insuredInstanceId === "string" ? value.insuredInstanceId : undefined
   };
 }
 

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -1031,6 +1031,21 @@ export interface GameState {
   pendingRunPreparations?: PreparedRunModifier[];
   pendingKeepsakeInstanceId?: string;
   pendingInsuredInstanceId?: string;
+  /** The Delve (v0.5) run layer. Optional/additive: absent on old saves and
+   *  whenever no delve run is active. See src/game/delve/types.ts. */
+  delveRun?: import("./delve/types").DelveRunState;
+  /** The raid pack carried into the active delve run (mirrors activeRun.raidInventory
+   *  for the old dungeon layer, tracked separately since DelveRunState itself holds
+   *  no inventory — the engine reports item/gold changes as events for the store). */
+  delveRaidPack?: Inventory;
+  /** Store-side bookkeeping for the active delve run that the pure engine doesn't
+   *  track itself (mirrors the run-start snapshot old runs take of keepsake/insurance). */
+  delveMeta?: {
+    startedAt: number;
+    xpGained: number;
+    keepsakeInstanceId?: string;
+    insuredInstanceId?: string;
+  };
 }
 
 export type RunEndReason =
@@ -1089,6 +1104,7 @@ export type ScreenId =
   | "village"
   | "dungeon"
   | "combat"
+  | "delve"
   | "runSummary"
   | "stash"
   | "character"

--- a/src/index.css
+++ b/src/index.css
@@ -2371,3 +2371,126 @@ button.combat-enemy:hover { border-color: var(--accent); background: var(--bg-3)
   gap: 8px;
   margin-top: 10px;
 }
+
+/* ---------------------------------------------------------------------
+   The Delve (v0.5) — one narrative column, no minimap. Reuses the v0.4
+   narrative-column/passage-choice look; only the status strip and light
+   tint are new. See docs/design/the-delve.md Pillar 4.
+   --------------------------------------------------------------------- */
+.delve-screen {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  transition: background 400ms ease, filter 400ms ease;
+}
+.delve-screen-dim { filter: saturate(0.9) brightness(0.96); }
+.delve-screen-dark {
+  filter: saturate(0.6) brightness(0.82);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0.15));
+}
+
+.delve-status-strip {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 14px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-1);
+}
+.delve-status-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-right: 6px;
+}
+.delve-status-hp { display: flex; align-items: center; }
+.delve-status-chip em {
+  font-style: normal;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.7rem;
+  margin-right: 4px;
+}
+.delve-abandon-btn { margin-left: auto; }
+
+.delve-lamp {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.86rem;
+  color: var(--text-dim);
+}
+.delve-lamp-glyph {
+  display: inline-block;
+  width: 10px;
+  height: 12px;
+  border-radius: 50% 50% 45% 45%;
+  background: var(--accent-2);
+  box-shadow: 0 0 6px 1px rgba(216, 178, 92, 0.55);
+}
+.delve-lamp-bright .delve-lamp-glyph { background: var(--accent-2); box-shadow: 0 0 7px 2px rgba(216, 178, 92, 0.6); }
+.delve-lamp-dim .delve-lamp-glyph { background: var(--warn); box-shadow: 0 0 5px 1px rgba(230, 134, 60, 0.45); }
+.delve-lamp-dark .delve-lamp-glyph { background: var(--text-muted); box-shadow: none; }
+.delve-lamp-dark .delve-lamp-value { color: var(--danger); }
+
+.delve-alertness-0 { color: var(--good); }
+.delve-alertness-1 { color: var(--text-dim); }
+.delve-alertness-2 { color: var(--accent-2); }
+.delve-alertness-3 { color: var(--warn); }
+.delve-alertness-4,
+.delve-alertness-5 { color: var(--danger); }
+
+.delve-column { gap: 6px; }
+.delve-entry {
+  margin: 0;
+  line-height: 1.55;
+  color: var(--text);
+}
+.delve-entry-room { font-size: 1.06rem; font-weight: 600; margin-top: 6px; }
+.delve-entry-sense { color: var(--text-dim); font-style: italic; }
+.delve-entry-action { color: var(--text); }
+.delve-entry-encounter { color: var(--warn); }
+.delve-entry-system { color: var(--accent-2); }
+.delve-entry-map { color: var(--text-dim); font-style: italic; }
+.delve-entry-dim { color: var(--text-muted); opacity: 0.66; }
+.delve-entry-dim.delve-entry-sense,
+.delve-entry-dim.delve-entry-map { color: var(--text-muted); }
+
+.delve-entry.delve-entry-in {
+  animation: delve-entry-fade-in 260ms ease-out backwards;
+}
+@keyframes delve-entry-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .delve-entry.delve-entry-in {
+    animation: none !important;
+    transform: none !important;
+    opacity: 1 !important;
+  }
+}
+
+.delve-choices {
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.delve-passage-choice {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font: inherit;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 100ms ease, background 100ms ease;
+}
+.delve-passage-choice:hover { border-color: var(--accent); background: var(--bg-2); }

--- a/src/screens/DelveScreen.tsx
+++ b/src/screens/DelveScreen.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "../components/Button";
+import { ConfirmDialog } from "../components/ConfirmDialog";
+import { useGameStore } from "../store/gameStore";
+import { getLightState } from "../game/delve/lamp";
+import { getThreatLevelFromPoints } from "../game/threat";
+import { THREAT_RULES } from "../game/constants";
+import { calculateInventoryWeight } from "../game/inventory";
+import { useStaggeredReveal } from "../components/useStaggeredReveal";
+import { buildChoiceList, type DelveChoice } from "./delveChoices";
+import type { DelveAction } from "../game/delve/types";
+import "./pacing.css";
+
+const NARRATIVE_REVEAL_INTERVAL_MS = 90;
+const DIM_TAIL_COUNT = 6;
+const TERMINAL_PAUSE_MS = 1400;
+
+export function DelveScreen() {
+  const run = useGameStore(s => s.state.delveRun);
+  const player = useGameStore(s => s.state.player);
+  const pack = useGameStore(s => s.state.delveRaidPack);
+  const performAction = useGameStore(s => s.performDelveAction);
+  const resolveDelveRunEnd = useGameStore(s => s.resolveDelveRunEnd);
+  const abandon = useGameStore(s => s.abandonDelveRun);
+
+  const [showAbandonConfirm, setShowAbandonConfirm] = useState(false);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const totalEntries = run?.narrative.length ?? 0;
+  const { revealed, isRevealing, skip } = useStaggeredReveal(totalEntries, NARRATIVE_REVEAL_INTERVAL_MS);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [revealed]);
+
+  // Terminal statuses (extracted/died) stay on screen just long enough to
+  // read the closing line, then hand off to the v0.4 run-summary flow.
+  useEffect(() => {
+    if (!run || run.status === "active") return;
+    const t = window.setTimeout(() => resolveDelveRunEnd(), TERMINAL_PAUSE_MS);
+    return () => window.clearTimeout(t);
+  }, [run?.status, run?.actionCount, resolveDelveRunEnd]);
+
+  const choices = useMemo(() => (run ? buildChoiceList(run) : []), [run]);
+
+  if (!run || !player) return <div className="screen">No active delve.</div>;
+
+  const lightState = getLightState(run.lamp);
+  const alertnessLevel = getThreatLevelFromPoints(run.alertness);
+  const alertnessLabel = THREAT_RULES.thresholds.find(t => t.level === alertnessLevel)?.label ?? "Quiet";
+  const carriedWeight = pack ? calculateInventoryWeight(pack) : 0;
+  const carryCapacity = player.derivedStats.carryCapacity;
+  const hpPct = player.maxHp > 0 ? Math.round((player.hp / player.maxHp) * 100) : 0;
+  const oilPct = run.lamp.capacity > 0 ? Math.round((run.lamp.oil / run.lamp.capacity) * 100) : 0;
+  const isOver = run.status !== "active";
+
+  const visibleNarrative = run.narrative.slice(0, revealed);
+  const dimBefore = Math.max(0, visibleNarrative.length - DIM_TAIL_COUNT);
+
+  function dispatch(action: DelveAction) {
+    if (isRevealing || isOver) return;
+    performAction(action);
+  }
+
+  return (
+    <div
+      className={`screen delve-screen delve-screen-${lightState}`}
+      onClick={() => isRevealing && skip()}
+    >
+      {player.hp / player.maxHp <= 0.25 && <div className="low-hp-vignette" aria-hidden="true" />}
+
+      <header className="delve-status-strip">
+        <div className="delve-status-hp">
+          <span className="delve-status-label">HP</span>
+          <div className="hp-bar hp-bar-compact" style={{ width: 140 }}>
+            <div className="hp-bar-fill" style={{ width: `${hpPct}%` }} />
+            <span className="hp-bar-label">{player.hp} / {player.maxHp}</span>
+          </div>
+        </div>
+        <div className={`delve-lamp delve-lamp-${lightState}`} title={`Lamp: ${lightState}`}>
+          <span className="delve-lamp-glyph" aria-hidden="true" />
+          <span className="delve-lamp-value">{run.lamp.oil}/{run.lamp.capacity}</span>
+          {run.lamp.flasksPacked > 0 && (
+            <span className="muted small">· {run.lamp.flasksPacked} flask{run.lamp.flasksPacked > 1 ? "s" : ""}</span>
+          )}
+        </div>
+        <span className="delve-status-chip"><em>Pack</em> {carriedWeight}/{carryCapacity}</span>
+        <span className={`delve-status-chip delve-alertness delve-alertness-${alertnessLevel}`}>
+          <em>Alertness</em> {alertnessLabel}
+        </span>
+        <Button variant="danger" className="delve-abandon-btn" onClick={() => setShowAbandonConfirm(true)}>
+          Abandon
+        </Button>
+      </header>
+
+      {showAbandonConfirm && (
+        <ConfirmDialog
+          title="Abandon the delve"
+          body="What you carry stays behind. The Warrens keep what they are given."
+          confirmLabel="Leave it all"
+          cancelLabel="Stay"
+          danger
+          onConfirm={() => { setShowAbandonConfirm(false); abandon(); }}
+          onCancel={() => setShowAbandonConfirm(false)}
+        />
+      )}
+
+      <div className="narrative-scroll" ref={scrollRef}>
+        <div className="narrative-column delve-column">
+          {visibleNarrative.map((entry, i) => (
+            <p
+              key={entry.id}
+              className={[
+                "delve-entry",
+                `delve-entry-${entry.kind}`,
+                "delve-entry-in",
+                i < dimBefore ? "delve-entry-dim" : ""
+              ].filter(Boolean).join(" ")}
+            >
+              {entry.text}
+            </p>
+          ))}
+
+          {!isOver && !isRevealing && (
+            <div className="delve-choices" onClick={event => event.stopPropagation()}>
+              {choices.map(choice => (
+                <ChoiceButton key={choiceKey(choice)} choice={choice} dispatch={dispatch} />
+              ))}
+              {choices.length === 0 && (
+                <p className="muted small">Nothing to do here but wait, and waiting is its own kind of noise.</p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function choiceKey(choice: DelveChoice): string {
+  switch (choice.kind) {
+    case "encounterOption": return `enc:${choice.optionKind}`;
+    case "fightStance": return `stance:${choice.stance}`;
+    case "move": return `move:${choice.direction}`;
+    case "crank": return `crank:${choice.extractId}`;
+    case "extract": return `extract:${choice.extractId}`;
+    case "descend": return `descend:${choice.stairRoomId}`;
+    default: return choice.kind;
+  }
+}
+
+function ChoiceButton({ choice, dispatch }: { choice: DelveChoice; dispatch: (action: DelveAction) => void }) {
+  switch (choice.kind) {
+    case "encounterOption":
+      return (
+        <Button
+          variant={choice.available ? "secondary" : "ghost"}
+          disabled={!choice.available}
+          title={choice.unavailableReason}
+          onClick={() => dispatch({ type: "encounterOption", kind: choice.optionKind })}
+        >
+          {choice.label}
+        </Button>
+      );
+    case "fightStance":
+      return (
+        <Button
+          className="btn-hero"
+          onClick={() => dispatch({ type: "fightBeat", stance: choice.stance })}
+        >
+          {choice.label}
+        </Button>
+      );
+    case "takeAllLoot":
+      return <Button onClick={() => dispatch({ type: "takeAllLoot" })}>{choice.label}</Button>;
+    case "leaveLoot":
+      return <Button variant="ghost" onClick={() => dispatch({ type: "leaveLoot" })}>{choice.label}</Button>;
+    case "move":
+      return (
+        <button
+          type="button"
+          className="passage-choice delve-passage-choice"
+          onClick={() => dispatch({ type: "move", direction: choice.direction })}
+        >
+          {choice.label}
+        </button>
+      );
+    case "search":
+      return <Button variant="secondary" onClick={() => dispatch({ type: "search" })}>{choice.label}</Button>;
+    case "listen":
+      return <Button variant="ghost" onClick={() => dispatch({ type: "listen" })}>{choice.label}</Button>;
+    case "refillLamp":
+      return <Button variant="secondary" onClick={() => dispatch({ type: "refillLamp" })}>{choice.label}</Button>;
+    case "consultMap":
+      return <Button variant="ghost" onClick={() => dispatch({ type: "consultMap" })}>{choice.label}</Button>;
+    case "crank":
+      return <Button variant="secondary" onClick={() => dispatch({ type: "crank", extractId: choice.extractId })}>{choice.label}</Button>;
+    case "extract":
+      return <Button className="btn-hero" onClick={() => dispatch({ type: "extract", extractId: choice.extractId })}>{choice.label}</Button>;
+    case "descend":
+      return <Button variant="secondary" onClick={() => dispatch({ type: "descend", stairRoomId: choice.stairRoomId })}>{choice.label}</Button>;
+    default:
+      return null;
+  }
+}

--- a/src/screens/delveChoices.ts
+++ b/src/screens/delveChoices.ts
@@ -1,0 +1,174 @@
+// Pure view-model derivation for DelveScreen: turns a DelveRunState into the
+// ordered list of choices the narrative column's foot should render. No
+// React here — kept pure and unit-testable (src/tests/delveScreenChoices.test.ts)
+// separately from the component that renders it.
+//
+// Priority, per docs/design/the-delve.md Pillar 4 and issue #37:
+//   1. An active encounter's options (+ fight stances, since applyDelveAction's
+//      fightBeat resolves a beat regardless of whether "fight" was chosen from
+//      the decision set first — see friction note in the PR description).
+//   2. Pending loot in the current room.
+//   3. Otherwise: exits as prose lines, plus contextual actions.
+import { getPlace } from "../game/delve/place";
+import type {
+  DelveRunState,
+  Direction,
+  EncounterOptionKind,
+  FightStance,
+  PlaceExit,
+  PlaceExtract,
+  SenseTag
+} from "../game/delve/types";
+
+export type DelveChoice =
+  | { kind: "encounterOption"; optionKind: EncounterOptionKind; label: string; available: boolean; unavailableReason?: string }
+  | { kind: "fightStance"; stance: FightStance; label: string }
+  | { kind: "takeAllLoot"; label: string }
+  | { kind: "leaveLoot"; label: string }
+  | { kind: "move"; direction: Direction; label: string }
+  | { kind: "search"; label: string }
+  | { kind: "listen"; label: string }
+  | { kind: "refillLamp"; label: string }
+  | { kind: "consultMap"; label: string }
+  | { kind: "crank"; extractId: string; label: string }
+  | { kind: "extract"; extractId: string; label: string }
+  | { kind: "descend"; stairRoomId: string; label: string };
+
+const SENSE_TEXT: Record<SenseTag, string> = {
+  tallow: "tallow smoke",
+  warmAir: "warm air",
+  coldDraft: "a cold draft",
+  waterSound: "the sound of water",
+  greaseSmell: "the smell of old grease",
+  rotSmell: "the smell of rot",
+  silence: "a dead silence",
+  chittering: "faint chittering",
+  lightBeyond: "a hint of light beyond",
+  narrowSqueeze: "a narrow squeeze"
+};
+
+const DIRECTION_LABELS: Record<Direction, string> = {
+  north: "North",
+  east: "East",
+  south: "South",
+  west: "West",
+  up: "Up",
+  down: "Down"
+};
+
+const FIGHT_STANCE_LABELS: Record<FightStance, string> = {
+  press: "Press the attack",
+  guard: "Guard",
+  breakAway: "Break away"
+};
+
+function exitButtonLabel(state: DelveRunState, roomId: string, exit: PlaceExit): string {
+  const senses = (exit.senses ?? []).map(s => SENSE_TEXT[s]).join(", ");
+  const doorState = state.doorOverrides[`${roomId}:${exit.direction}`];
+  let label = `${DIRECTION_LABELS[exit.direction]} — ${senses || "a way on"}`;
+  if (doorState === "locked") label += " (locked)";
+  else if (doorState === "jammed") label += " (jammed)";
+  else if (doorState === "shut") label += " (shut)";
+  return label;
+}
+
+/** Every place extract co-located with the current room. */
+function extractsInCurrentRoom(state: DelveRunState): PlaceExtract[] {
+  const place = getPlace(state.placeId);
+  const floor = place.floors.find(f => f.floor === state.floor);
+  if (!floor) return [];
+  return floor.extracts.filter(e => e.roomId === state.currentRoomId);
+}
+
+function crankOrExtractChoices(state: DelveRunState): DelveChoice[] {
+  const choices: DelveChoice[] = [];
+  for (const extract of extractsInCurrentRoom(state)) {
+    if (extract.condition === "cranked") {
+      const required = extract.cranksRequired ?? 1;
+      const done = state.cranksDone[extract.id] ?? 0;
+      if (done < required) {
+        choices.push({
+          kind: "crank",
+          extractId: extract.id,
+          label: `Crank the winch (${done}/${required})`
+        });
+        continue;
+      }
+    }
+    choices.push({ kind: "extract", extractId: extract.id, label: extract.label });
+  }
+  return choices;
+}
+
+/**
+ * Whether a next floor exists to descend to. There is no authored "this is
+ * the stair" marker on PlaceRoom/PlaceFloor (see friction notes) — descend is
+ * offered from any room on a floor once a next floor exists, matching
+ * applyDelveAction's own permissiveness (it only checks the target floor
+ * exists and the player is standing in the room named as `stairRoomId`).
+ */
+function hasNextFloor(state: DelveRunState): boolean {
+  const place = getPlace(state.placeId);
+  return place.floors.some(f => f.floor === state.floor + 1);
+}
+
+export function buildChoiceList(state: DelveRunState): DelveChoice[] {
+  if (state.status !== "active") return [];
+
+  const encounter = state.activeEncounter;
+  if (encounter) {
+    const choices: DelveChoice[] = [];
+    for (const option of encounter.options) {
+      if (option.kind === "fight") continue; // realized via stance buttons below
+      choices.push({
+        kind: "encounterOption",
+        optionKind: option.kind,
+        label: option.label,
+        available: option.available,
+        unavailableReason: option.unavailableReason
+      });
+    }
+    for (const stance of ["press", "guard", "breakAway"] as const) {
+      choices.push({ kind: "fightStance", stance, label: FIGHT_STANCE_LABELS[stance] });
+    }
+    return choices;
+  }
+
+  const pool = state.pendingLoot[state.currentRoomId];
+  if (pool && (pool.items.length > 0 || pool.gold > 0)) {
+    return [
+      { kind: "takeAllLoot", label: "Take All" },
+      { kind: "leaveLoot", label: "Leave the Rest" }
+    ];
+  }
+
+  const place = getPlace(state.placeId);
+  const floor = place.floors.find(f => f.floor === state.floor);
+  const room = floor?.rooms.find(r => r.id === state.currentRoomId);
+  const choices: DelveChoice[] = [];
+
+  if (room) {
+    for (const exit of room.exits) {
+      choices.push({ kind: "move", direction: exit.direction, label: exitButtonLabel(state, room.id, exit) });
+    }
+  }
+
+  if (!state.searchedRoomIds.includes(state.currentRoomId)) {
+    choices.push({ kind: "search", label: "Search" });
+  }
+  choices.push({ kind: "listen", label: "Listen" });
+  if (state.lamp.flasksPacked > 0) {
+    choices.push({ kind: "refillLamp", label: "Refill the lamp" });
+  }
+  if (state.hasMapItem && state.lamp.oil > 0) {
+    choices.push({ kind: "consultMap", label: "Consult the map" });
+  }
+
+  choices.push(...crankOrExtractChoices(state));
+
+  if (hasNextFloor(state)) {
+    choices.push({ kind: "descend", stairRoomId: state.currentRoomId, label: "Descend" });
+  }
+
+  return choices;
+}

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -45,13 +45,15 @@ import { appendRunSummary, buildRunSummary } from "../game/runSummary";
 import { getModifier, recalculateCharacterStats } from "../game/characterMath";
 import { THREAT_RULES } from "../game/constants";
 import type { CombatThreatDelta } from "../game/combat";
-import type { DungeonLogEntryType, ThreatChange, ThreatChangeReason } from "../game/types";
+import type { DungeonLogEntryType, ThreatChange, ThreatChangeReason, ThreatState } from "../game/types";
 import {
   applyDelveStrainChange,
   applyThreatChange,
   calculateDescendStrainGain,
   createThreatStateWithCarryover,
-  getThreatModifiers
+  getThreatModifiers,
+  getThreatLevelFromPoints,
+  createInitialDelveStrainState
 } from "../game/threat";
 import { addDungeonLogEntry } from "../game/dungeonLog";
 import { clearPendingLoot, depositPendingLoot, getPendingLoot, hasPendingLoot } from "../game/pendingLoot";
@@ -97,6 +99,8 @@ import { previewEquipmentChange as previewEquipmentChangeBase } from "../game/eq
 import { addItemState, removeItemState } from "../game/itemStates";
 import { resolveCombatAction as resolveCombatActionBase } from "../game/combatActions";
 import { playSfx, setAudioMuted } from "../game/audio";
+import { createDelveRun, applyDelveAction } from "../game/delve/delveRun";
+import type { DelveAction, DelveRunDeps, DelveRunState } from "../game/delve/types";
 
 export interface GameStore {
   screen: ScreenId;
@@ -188,6 +192,12 @@ export interface GameStore {
   setKeepsake: (itemInstanceId: string) => void;
   clearKeepsake: () => void;
   startDungeonRunWithPreparations: (params?: { biome?: import("../game/types").DungeonBiome; seed?: string }) => void;
+
+  // The Delve (v0.5 run layer)
+  startDelveRun: (placeId: string) => void;
+  performDelveAction: (action: DelveAction) => void;
+  resolveDelveRunEnd: () => void;
+  abandonDelveRun: () => void;
 
   // v0.4 integration wrappers
   awardXp: (xp: number) => void;
@@ -497,6 +507,125 @@ export const useGameStore = create<GameStore>((set, get) => ({
     };
     set({ state: next, lastDeathSummary: summary, lastExtractionSummary: undefined, screen: "runSummary" });
     persist(next);
+  },
+
+  startDelveRun: placeId => {
+    const s = get().state;
+    if (!s.player) return;
+    const raidPack = s.preparedInventory ?? createEmptyInventory();
+    const delveRun = createDelveRun({
+      placeId,
+      seed: String(Date.now()),
+      flasksPacked: raidPack.items
+        .filter(i => i.tags?.includes("oilFlask"))
+        .reduce((n, i) => n + i.quantity, 0)
+    });
+    const next: GameState = {
+      ...s,
+      delveRun,
+      delveRaidPack: raidPack,
+      preparedInventory: createEmptyInventory(),
+      delveMeta: {
+        startedAt: Date.now(),
+        xpGained: 0,
+        keepsakeInstanceId: resolveKeepsakeForRun(s, raidPack),
+        insuredInstanceId: resolveInsuredForRun(s, s.player)
+      },
+      pendingKeepsakeInstanceId: undefined,
+      pendingInsuredInstanceId: undefined
+    };
+    set({ state: next, screen: "delve" });
+    persist(next);
+  },
+
+  performDelveAction: action => {
+    const s = get().state;
+    if (!s.delveRun || !s.player) return;
+    const raidPack = s.delveRaidPack ?? createEmptyInventory();
+    const deps: DelveRunDeps = {
+      character: s.player,
+      carriedItems: raidPack.items,
+      carriedWeight: calculateInventoryWeight(raidPack),
+      carryCapacity: s.player.derivedStats.carryCapacity
+    };
+    const result = applyDelveAction(s.delveRun, action, deps);
+
+    let player = s.player;
+    let pack = raidPack;
+    let xpGained = s.delveMeta?.xpGained ?? 0;
+    let terminal: "extracted" | "died" | undefined;
+
+    for (const event of result.events) {
+      switch (event.kind) {
+        case "hpDelta": {
+          player = { ...player, hp: Math.max(0, Math.min(player.maxHp, player.hp + event.amount)) };
+          break;
+        }
+        case "itemsTaken": {
+          for (const item of event.items) pack = addItem(pack, item);
+          if (event.gold > 0) pack = { ...pack, gold: pack.gold + event.gold };
+          break;
+        }
+        case "flaskConsumed": {
+          pack = removeOneItemByTag(pack, "oilFlask");
+          break;
+        }
+        case "itemConsumed": {
+          pack = removeOneItemByTag(pack, event.tag);
+          break;
+        }
+        case "enemyDefeated": {
+          const def = tryGetEnemy(event.enemyId);
+          if (def) {
+            xpGained += def.xpReward;
+            player = { ...player, xp: player.xp + def.xpReward };
+          }
+          break;
+        }
+        case "extracted": terminal = "extracted"; break;
+        case "died": terminal = "died"; break;
+        default: break;
+      }
+    }
+
+    const nextMeta = { ...(s.delveMeta ?? { startedAt: Date.now(), xpGained: 0 }), xpGained };
+
+    // Terminal statuses (extracted/died) are NOT resolved into the v0.4
+    // run-summary flow here — the screen stays up long enough to show a
+    // brief terminal narrative line first (Pillar 4), then calls
+    // resolveDelveRunEnd() after a short pause. See that action below.
+    let delveRun = result.state;
+    if (terminal === "extracted") {
+      delveRun = appendDelveNarrativeEntry(delveRun, "You come up into evening air.");
+    } else if (terminal === "died") {
+      delveRun = appendDelveNarrativeEntry(delveRun, "The dark closes over you. The Warrens keep what they took.");
+    }
+
+    const next: GameState = {
+      ...s,
+      player,
+      delveRun,
+      delveRaidPack: pack,
+      delveMeta: nextMeta
+    };
+    set({ state: next });
+    persist(next);
+  },
+
+  resolveDelveRunEnd: () => {
+    const s = get().state;
+    if (!s.delveRun || s.delveRun.status === "active") return;
+    if (s.delveRun.status === "extracted") {
+      finishDelveRunWithExtraction(get, set, s, s.delveRun);
+    } else if (s.delveRun.status === "dead") {
+      finishDelveRunWithDeath(get, set, s, s.delveRun);
+    }
+  },
+
+  abandonDelveRun: () => {
+    const s = get().state;
+    if (!s.delveRun || !s.player) return;
+    finishDelveRunAbandoned(get, set, s, s.delveRun);
   },
 
   moveToRoom: roomId => {
@@ -2053,6 +2182,7 @@ function getScreenForLoadedState(state: GameState): ScreenId {
   if (!state.player) return "mainMenu";
   if (state.activeCombat && !state.activeCombat.over) return "combat";
   if (state.activeRun?.status === "active") return "dungeon";
+  if (state.delveRun?.status === "active") return "delve";
   return "village";
 }
 
@@ -2228,6 +2358,184 @@ function finishRunWithExtraction(
   set({ state: next, lastExtractionSummary: result.summary, lastDeathSummary: undefined, screen: "runSummary" });
   persist(next);
   playSfx("extract");
+}
+
+// ---------------------------------------------------------------------------
+// The Delve (v0.5 run layer) — the pure engine in src/game/delve/ knows
+// nothing about Character/Inventory/village progression, so the store bridges
+// it to the existing v0.4 run-summary / death-cost / extraction-reward flows
+// via a lightweight adapter object shaped like a DungeonRun. Those flows only
+// ever read raidInventory, xpGained, loadoutSnapshot, keepsakeInstanceId,
+// insuredInstanceId, and (on death) roomGraph/visitedRoomIds for the
+// "how far from an extract" stat — all safe to fake or leave empty here.
+// See friction notes in the PR description: quests and run preparations
+// aren't wired into delve runs yet (that's the village-integration work in
+// issue #38), so activeQuestIds/questProgressAtStart are empty.
+// ---------------------------------------------------------------------------
+
+function appendDelveNarrativeEntry(run: DelveRunState, text: string): DelveRunState {
+  const entry = { id: `terminal_${run.actionCount}`, kind: "system" as const, text };
+  return { ...run, narrative: [...run.narrative, entry] };
+}
+
+function removeOneItemByTag(inv: Inventory, tag: string): Inventory {
+  const item = inv.items.find(i => i.tags?.includes(tag));
+  if (!item) return inv;
+  return removeItem(inv, item.instanceId, 1);
+}
+
+function tryGetEnemy(id: string) {
+  try { return getEnemy(id); } catch { return undefined; }
+}
+
+function buildDelveRunAdapter(
+  state: GameState,
+  delveRun: DelveRunState,
+  pack: Inventory,
+  xpGained: number,
+  status: "extracted" | "dead" | "abandoned"
+): DungeonRun {
+  const meta = state.delveMeta;
+  return {
+    runId: `delve:${delveRun.placeId}:${delveRun.seed}`,
+    seed: delveRun.seed,
+    generatorVersion: 1,
+    biome: delveRun.placeId as DungeonRun["biome"],
+    tier: delveRun.tier,
+    status,
+    startedAt: meta?.startedAt ?? Date.now(),
+    currentRoomId: delveRun.currentRoomId,
+    roomGraph: [],
+    visitedRoomIds: delveRun.visitedRoomIds,
+    raidInventory: pack,
+    loadoutSnapshot: state.player ? collectLoadoutSnapshot(state.player) : [],
+    activeQuestIds: [],
+    questProgressAtStart: {},
+    xpGained,
+    roomsVisitedBeforeDepth: 0,
+    roomsCompletedBeforeDepth: 0,
+    dangerLevel: 0,
+    threat: {
+      points: delveRun.alertness,
+      level: getThreatLevelFromPoints(delveRun.alertness),
+      maxLevel: THREAT_RULES.maxLevel as ThreatState["maxLevel"],
+      lastChangedAt: Date.now(),
+      changes: []
+    },
+    delveStrain: createInitialDelveStrainState(),
+    knownRoomIntel: {},
+    dungeonLog: [],
+    keepsakeInstanceId: meta?.keepsakeInstanceId,
+    insuredInstanceId: meta?.insuredInstanceId
+  };
+}
+
+function clearDelveRunState(s: GameState): Pick<GameState, "delveRun" | "delveRaidPack" | "delveMeta"> {
+  return { delveRun: undefined, delveRaidPack: undefined, delveMeta: undefined };
+}
+
+function finishDelveRunWithExtraction(
+  get: () => GameStore,
+  set: (partial: Partial<GameStore>) => void,
+  s: GameState,
+  delveRun: DelveRunState
+) {
+  if (!s.player || !s.village) {
+    const cleared: GameState = { ...s, ...clearDelveRunState(s) };
+    set({ state: cleared, screen: "village" });
+    persist(cleared);
+    return;
+  }
+  const pack = s.delveRaidPack ?? createEmptyInventory();
+  const xpGained = s.delveMeta?.xpGained ?? 0;
+  const fakeRun = buildDelveRunAdapter(s, delveRun, pack, xpGained, "extracted");
+  const rng = createRng(`delveExtract:${fakeRun.seed}`);
+  const result = applyExtractionRewards({ player: s.player, village: s.village, stash: s.stash, run: fakeRun, rng });
+  const leveledPlayer = applyXpAndLevel(result.player);
+  const runSummary = buildRunSummary({
+    run: fakeRun,
+    village: result.village,
+    reason: "extracted",
+    reasonText: "You come up into evening air, the Warrens behind you.",
+    extraction: result.summary
+  });
+  const finalState: GameState = {
+    ...s,
+    ...clearDelveRunState(s),
+    player: leveledPlayer,
+    village: result.village,
+    stash: result.stash,
+    lastRunSummary: runSummary,
+    runSummaries: appendRunSummary(s.runSummaries, runSummary)
+  };
+  set({ state: finalState, lastExtractionSummary: result.summary, lastDeathSummary: undefined, screen: "runSummary" });
+  persist(finalState);
+  playSfx("extract");
+}
+
+function finishDelveRunWithDeath(
+  get: () => GameStore,
+  set: (partial: Partial<GameStore>) => void,
+  s: GameState,
+  delveRun: DelveRunState
+) {
+  if (!s.player) return;
+  const pack = s.delveRaidPack ?? createEmptyInventory();
+  const xpGained = s.delveMeta?.xpGained ?? 0;
+  const fakeRun = buildDelveRunAdapter(s, delveRun, pack, xpGained, "dead");
+  const { run: deadRun, player: recoveredPlayer, stash, summary } = resolveDeathOutcome({
+    run: fakeRun,
+    player: s.player,
+    stash: s.stash
+  });
+  const runSummary = buildRunSummary({
+    run: deadRun,
+    village: s.village,
+    reason: "dead",
+    reasonText: "The Warrens keep what they took. You do not come back up.",
+    death: summary
+  });
+  const finalState: GameState = {
+    ...s,
+    ...clearDelveRunState(s),
+    player: recoveredPlayer,
+    stash,
+    lastRunSummary: runSummary,
+    runSummaries: appendRunSummary(s.runSummaries, runSummary)
+  };
+  set({ state: finalState, lastDeathSummary: summary, lastExtractionSummary: undefined, screen: "runSummary" });
+  persist(finalState);
+  playSfx("death");
+}
+
+function finishDelveRunAbandoned(
+  get: () => GameStore,
+  set: (partial: Partial<GameStore>) => void,
+  s: GameState,
+  delveRun: DelveRunState
+) {
+  if (!s.player) return;
+  const pack = s.delveRaidPack ?? createEmptyInventory();
+  const xpGained = s.delveMeta?.xpGained ?? 0;
+  const fakeRun = buildDelveRunAdapter(s, delveRun, pack, xpGained, "abandoned");
+  const { run, player, stash, summary } = resolveAbandonOutcome({ run: fakeRun, player: s.player, stash: s.stash });
+  const runSummary = buildRunSummary({
+    run,
+    village: s.village,
+    reason: "abandoned",
+    reasonText: "You cut the line and left the raid pack behind.",
+    death: summary
+  });
+  const finalState: GameState = {
+    ...s,
+    ...clearDelveRunState(s),
+    player,
+    stash,
+    lastRunSummary: runSummary,
+    runSummaries: appendRunSummary(s.runSummaries, runSummary)
+  };
+  set({ state: finalState, lastDeathSummary: summary, lastExtractionSummary: undefined, screen: "runSummary" });
+  persist(finalState);
 }
 
 function handleExtractionResult(

--- a/src/tests/delveEncounters.test.ts
+++ b/src/tests/delveEncounters.test.ts
@@ -1,0 +1,470 @@
+import { describe, it, expect } from "vitest";
+import {
+  openEncounter,
+  resolveOption,
+  resolveFightBeat,
+  slipChance,
+  type DelveEncounterBeatResult
+} from "../game/delve/encounters";
+import type { ActiveEncounter, Hunter, LightState } from "../game/delve/types";
+import { ENEMIES } from "../data/enemies";
+import { CharacterCreationService, createEmptyDraft } from "../game/characterCreation";
+import { createRng } from "../game/rng";
+import type { Character, ItemInstance } from "../game/types";
+
+const ROOM_ID = "warrens_hall";
+const PREV_ROOM_ID = "warrens_entry";
+
+function buildCharacter(seed: string): Character {
+  let draft = createEmptyDraft(seed);
+  draft = CharacterCreationService.setName(draft, "Delver");
+  draft = CharacterCreationService.selectAncestry(draft, "human");
+  draft = CharacterCreationService.selectClass(draft, "warrior");
+  draft = CharacterCreationService.rollAllAbilityScores(draft);
+  draft = CharacterCreationService.autoAssignScoresForClass(draft);
+  draft = CharacterCreationService.chooseStarterKit(draft, "warrior_sword_shield");
+  return CharacterCreationService.finalizeCharacter(draft).character;
+}
+
+function buildHunter(enemyId: string, overrides: Partial<Hunter> = {}): Hunter {
+  return { id: "hunter_1", enemyId, roomId: ROOM_ID, state: "hunting", ...overrides };
+}
+
+function rationItem(): ItemInstance {
+  return {
+    instanceId: "item_ration",
+    templateId: "ration_stub",
+    name: "Dried Rations",
+    category: "consumable",
+    rarity: "common",
+    description: "Hard bread and jerky.",
+    value: 2,
+    weight: 1,
+    stackable: true,
+    quantity: 1,
+    tags: ["ration"]
+  };
+}
+
+describe("delve encounters: option availability matrix", () => {
+  const character = buildCharacter("avail-1");
+
+  it("offers fight and slipPast/fallBack/parley in a well-lit, unencumbered, followed-from room", () => {
+    const encounter = openEncounter({
+      hunter: buildHunter("goblin_snare"),
+      character,
+      carriedItems: [],
+      lightState: "bright",
+      packRatio: 0.2,
+      cameFromRoomId: PREV_ROOM_ID,
+      alertnessLevel: 1,
+      adjacentRoomIds: ["warrens_side"],
+      rng: createRng("avail-1")
+    });
+
+    const byKind = Object.fromEntries(encounter.options.map(o => [o.kind, o]));
+    expect(byKind.fight?.available).toBe(true);
+    expect(byKind.slipPast?.available).toBe(true);
+    expect(byKind.fallBack?.available).toBe(true);
+    expect(byKind.parley?.available).toBe(true); // goblin_snare is lootTag "goblin"
+    expect(byKind.lure?.available).toBe(true); // bright + adjacent room
+    expect(byKind.throwRations?.available).toBe(false);
+    expect(byKind.throwRations?.unavailableReason).toBe("No rations to spare");
+  });
+
+  it("disables slipPast in the dark with the diegetic reason", () => {
+    const encounter = openEncounter({
+      hunter: buildHunter("goblin_snare"),
+      character,
+      carriedItems: [],
+      lightState: "dark",
+      packRatio: 0.2,
+      cameFromRoomId: PREV_ROOM_ID,
+      alertnessLevel: 1,
+      adjacentRoomIds: [],
+      rng: createRng("avail-2")
+    });
+    const slip = encounter.options.find(o => o.kind === "slipPast")!;
+    expect(slip.available).toBe(false);
+    expect(slip.unavailableReason).toBe("No light to slip by");
+  });
+
+  it("disables fallBack when there is nowhere behind you", () => {
+    const encounter = openEncounter({
+      hunter: buildHunter("goblin_snare"),
+      character,
+      carriedItems: [],
+      lightState: "bright",
+      packRatio: 0.2,
+      cameFromRoomId: undefined,
+      alertnessLevel: 1,
+      adjacentRoomIds: [],
+      rng: createRng("avail-3")
+    });
+    const fallBack = encounter.options.find(o => o.kind === "fallBack")!;
+    expect(fallBack.available).toBe(false);
+    expect(fallBack.unavailableReason).toBe("Nowhere behind you");
+  });
+
+  it("disables parley against non-goblin (vermin/beast/undead) enemies", () => {
+    const encounter = openEncounter({
+      hunter: buildHunter("crypt_bone_rat"),
+      character,
+      carriedItems: [],
+      lightState: "bright",
+      packRatio: 0.2,
+      cameFromRoomId: PREV_ROOM_ID,
+      alertnessLevel: 1,
+      adjacentRoomIds: [],
+      rng: createRng("avail-4")
+    });
+    const parley = encounter.options.find(o => o.kind === "parley")!;
+    expect(parley.available).toBe(false);
+    expect(parley.unavailableReason).toBe("It won't understand you");
+  });
+
+  it("enables throwRations only when carrying a ration-tagged item", () => {
+    const encounter = openEncounter({
+      hunter: buildHunter("goblin_snare"),
+      character,
+      carriedItems: [rationItem()],
+      lightState: "bright",
+      packRatio: 0.2,
+      cameFromRoomId: PREV_ROOM_ID,
+      alertnessLevel: 1,
+      adjacentRoomIds: [],
+      rng: createRng("avail-5")
+    });
+    const throwRations = encounter.options.find(o => o.kind === "throwRations")!;
+    expect(throwRations.available).toBe(true);
+  });
+
+  it("disables lure outside bright light or without an adjacent room", () => {
+    const dim = openEncounter({
+      hunter: buildHunter("goblin_snare"),
+      character,
+      carriedItems: [],
+      lightState: "dim",
+      packRatio: 0.2,
+      cameFromRoomId: PREV_ROOM_ID,
+      alertnessLevel: 1,
+      adjacentRoomIds: ["warrens_side"],
+      rng: createRng("avail-6")
+    });
+    expect(dim.options.find(o => o.kind === "lure")!.available).toBe(false);
+
+    const noAdjacent = openEncounter({
+      hunter: buildHunter("goblin_snare"),
+      character,
+      carriedItems: [],
+      lightState: "bright",
+      packRatio: 0.2,
+      cameFromRoomId: PREV_ROOM_ID,
+      alertnessLevel: 1,
+      adjacentRoomIds: [],
+      rng: createRng("avail-7")
+    });
+    expect(noAdjacent.options.find(o => o.kind === "lure")!.available).toBe(false);
+  });
+
+  it("slipChance worsens with a heavier pack and with dimmer light", () => {
+    const bright = slipChance({ packRatio: 0, lightState: "bright", agilityModifier: 0 });
+    const heavy = slipChance({ packRatio: 0.9, lightState: "bright", agilityModifier: 0 });
+    const dim = slipChance({ packRatio: 0, lightState: "dim", agilityModifier: 0 });
+    expect(heavy).toBeLessThan(bright);
+    expect(dim).toBeLessThan(bright);
+  });
+});
+
+describe("delve encounters: slip/fallback failure degrades to a free exchange", () => {
+  it("a failed slipPast keeps the encounter open and lets the enemy land a free hit", () => {
+    const character = buildCharacter("degrade-1");
+    const hunter = buildHunter("goblin_warrens_brute");
+    const encounter: ActiveEncounter = openEncounter({
+      hunter,
+      character,
+      carriedItems: [],
+      lightState: "bright",
+      packRatio: 0.95, // heavy pack tanks slip chance toward the floor
+      cameFromRoomId: PREV_ROOM_ID,
+      alertnessLevel: 5,
+      adjacentRoomIds: [],
+      rng: createRng("degrade-1")
+    });
+
+    // Sweep seeds until we observe a failed slip (chance is low but nonzero
+    // outcomes both ways are required, so a small sweep is deterministic and
+    // fast rather than flaky).
+    let sawFailure = false;
+    for (let i = 0; i < 30; i++) {
+      const rng = createRng(`degrade-slip-${i}`);
+      const result: DelveEncounterBeatResult = resolveOption({
+        encounter,
+        kind: "slipPast",
+        character,
+        lightState: "bright",
+        packRatio: 0.95,
+        alertnessLevel: 5,
+        rng,
+        roomId: ROOM_ID
+      });
+      if (result.outcome !== "escaped") {
+        sawFailure = true;
+        expect(result.over === false || result.outcome === "dead").toBe(true);
+        expect(result.noise).toEqual({ roomId: ROOM_ID, loudness: 3, cause: "fightBeat" });
+        expect(result.enemyHpDelta).toBe(0); // the enemy gets a free exchange; player doesn't hit back
+        expect(result.oilAction).toBe("encounterBeat");
+        if (result.over === false) {
+          expect(result.playerHpDelta).toBeLessThanOrEqual(0);
+        }
+      }
+    }
+    expect(sawFailure).toBe(true);
+  });
+
+  it("a successful slipPast ends the encounter with move noise", () => {
+    const character = buildCharacter("degrade-2");
+    const hunter = buildHunter("goblin_candle");
+    const encounter = openEncounter({
+      hunter,
+      character,
+      carriedItems: [],
+      lightState: "bright",
+      packRatio: 0,
+      cameFromRoomId: PREV_ROOM_ID,
+      alertnessLevel: 0,
+      adjacentRoomIds: [],
+      rng: createRng("degrade-2")
+    });
+
+    let sawSuccess = false;
+    for (let i = 0; i < 20; i++) {
+      const result = resolveOption({
+        encounter,
+        kind: "slipPast",
+        character,
+        lightState: "bright",
+        packRatio: 0,
+        alertnessLevel: 0,
+        rng: createRng(`degrade-slip-success-${i}`),
+        roomId: ROOM_ID
+      });
+      if (result.outcome === "escaped") {
+        sawSuccess = true;
+        expect(result.over).toBe(true);
+        expect(result.noise.cause).toBe("move");
+        expect(result.oilAction).toBe("encounterBeat");
+      }
+    }
+    expect(sawSuccess).toBe(true);
+  });
+});
+
+describe("delve encounters: fight beats end in 1-3 beats against tier-1 bestiary", () => {
+  const TIER_ONE_ENEMY_IDS = ENEMIES.filter(e => e.tier === 1).map(e => e.id);
+
+  it("simulates every tier-1 enemy across many seeds and reports the beat-count distribution", () => {
+    const beatCounts: number[] = [];
+    let wins = 0;
+    let deaths = 0;
+
+    for (const enemyId of TIER_ONE_ENEMY_IDS) {
+      for (let seedIdx = 0; seedIdx < 8; seedIdx++) {
+        const seed = `beatsim-${enemyId}-${seedIdx}`;
+        const character = buildCharacter(seed);
+        const hunter = buildHunter(enemyId);
+        const encounter = openEncounter({
+          hunter,
+          character,
+          carriedItems: [],
+          lightState: "bright",
+          packRatio: 0.3,
+          cameFromRoomId: PREV_ROOM_ID,
+          alertnessLevel: 1,
+          adjacentRoomIds: [],
+          rng: createRng(`${seed}:open`)
+        });
+
+        let enemyHp = encounter.enemyHp;
+        let playerHp = character.hp;
+        let beats = 0;
+        let outcome: "won" | "dead" | undefined;
+
+        for (let beat = 1; beat <= 10; beat++) {
+          beats = beat;
+          const liveEncounter: ActiveEncounter = { ...encounter, enemyHp, beat };
+          const liveCharacter: Character = { ...character, hp: playerHp };
+          const result = resolveFightBeat({
+            encounter: liveEncounter,
+            stance: "press",
+            character: liveCharacter,
+            rng: createRng(`${seed}:beat-${beat}`),
+            lightState: "bright",
+            roomId: ROOM_ID
+          });
+          enemyHp = Math.max(0, enemyHp + result.enemyHpDelta);
+          playerHp = playerHp + result.playerHpDelta;
+          expect(result.noise).toEqual({ roomId: ROOM_ID, loudness: 3, cause: "fightBeat" });
+          expect(result.oilAction).toBe("encounterBeat");
+          if (result.over) {
+            outcome = result.outcome === "dead" ? "dead" : "won";
+            break;
+          }
+        }
+
+        beatCounts.push(beats);
+        if (outcome === "won") wins += 1;
+        if (outcome === "dead") deaths += 1;
+      }
+    }
+
+    const max = Math.max(...beatCounts);
+    const avg = beatCounts.reduce((s, v) => s + v, 0) / beatCounts.length;
+    const within3 = beatCounts.filter(b => b <= 3).length;
+
+    // eslint-disable-next-line no-console
+    console.info("delve fight beat-count distribution", {
+      runs: beatCounts.length,
+      wins,
+      deaths,
+      avgBeats: Number(avg.toFixed(2)),
+      maxBeats: max,
+      within3Beats: within3,
+      within3Pct: Number(((within3 / beatCounts.length) * 100).toFixed(1))
+    });
+
+    expect(wins).toBeGreaterThan(deaths);
+    expect(avg).toBeLessThanOrEqual(3);
+    expect(within3 / beatCounts.length).toBeGreaterThanOrEqual(0.85);
+    expect(max).toBeLessThanOrEqual(5);
+  });
+});
+
+describe("delve encounters: determinism", () => {
+  it("resolveFightBeat is deterministic for the same seed and inputs", () => {
+    const character = buildCharacter("det-1");
+    const hunter = buildHunter("goblin_snare");
+    const encounter = openEncounter({
+      hunter,
+      character,
+      carriedItems: [],
+      lightState: "bright",
+      packRatio: 0.2,
+      cameFromRoomId: PREV_ROOM_ID,
+      alertnessLevel: 1,
+      adjacentRoomIds: [],
+      rng: createRng("det-1:open")
+    });
+
+    const run = () =>
+      resolveFightBeat({
+        encounter,
+        stance: "press",
+        character,
+        rng: createRng("det-1:beat-1"),
+        lightState: "bright",
+        roomId: ROOM_ID
+      });
+
+    const a = run();
+    const b = run();
+    expect(a).toEqual(b);
+  });
+
+  it("openEncounter is deterministic for the same seed", () => {
+    const character = buildCharacter("det-2");
+    const hunter = buildHunter("goblin_snare");
+    const build = () =>
+      openEncounter({
+        hunter,
+        character,
+        carriedItems: [],
+        lightState: "bright",
+        packRatio: 0.2,
+        cameFromRoomId: PREV_ROOM_ID,
+        alertnessLevel: 1,
+        adjacentRoomIds: [],
+        rng: createRng("det-2:open")
+      });
+    expect(build()).toEqual(build());
+  });
+});
+
+describe("delve encounters: noise and oil emissions", () => {
+  const character = buildCharacter("noise-1");
+
+  it("breakAway always emits flee noise (loudness 4), win/press/guard emit fightBeat (loudness 3)", () => {
+    const hunter = buildHunter("goblin_snare");
+    const encounter = openEncounter({
+      hunter,
+      character,
+      carriedItems: [],
+      lightState: "bright",
+      packRatio: 0.2,
+      cameFromRoomId: PREV_ROOM_ID,
+      alertnessLevel: 1,
+      adjacentRoomIds: [],
+      rng: createRng("noise-1:open")
+    });
+
+    const breakAwayResult = resolveFightBeat({
+      encounter,
+      stance: "breakAway",
+      character,
+      rng: createRng("noise-1:break"),
+      lightState: "bright",
+      roomId: ROOM_ID
+    });
+    expect(breakAwayResult.noise).toEqual({ roomId: ROOM_ID, loudness: 4, cause: "flee" });
+
+    const pressResult = resolveFightBeat({
+      encounter,
+      stance: "press",
+      character,
+      rng: createRng("noise-1:press"),
+      lightState: "bright",
+      roomId: ROOM_ID
+    });
+    expect(pressResult.noise).toEqual({ roomId: ROOM_ID, loudness: 3, cause: "fightBeat" });
+
+    const guardResult = resolveFightBeat({
+      encounter,
+      stance: "guard",
+      character,
+      rng: createRng("noise-1:guard"),
+      lightState: "bright",
+      roomId: ROOM_ID
+    });
+    expect(guardResult.noise).toEqual({ roomId: ROOM_ID, loudness: 3, cause: "fightBeat" });
+  });
+
+  it("every option resolution and fight beat costs the encounterBeat oil action", () => {
+    const hunter = buildHunter("goblin_snare");
+    const encounter = openEncounter({
+      hunter,
+      character,
+      carriedItems: [rationItem()],
+      lightState: "bright",
+      packRatio: 0.2,
+      cameFromRoomId: PREV_ROOM_ID,
+      alertnessLevel: 1,
+      adjacentRoomIds: ["warrens_side"],
+      rng: createRng("noise-2:open")
+    });
+
+    const kinds = ["slipPast", "fallBack", "parley", "throwRations", "lure"] as const;
+    for (const kind of kinds) {
+      const result = resolveOption({
+        encounter,
+        kind,
+        character,
+        lightState: "bright",
+        packRatio: 0.2,
+        alertnessLevel: 1,
+        rng: createRng(`noise-2:${kind}`),
+        roomId: ROOM_ID
+      });
+      expect(result.oilAction).toBe("encounterBeat");
+    }
+  });
+});

--- a/src/tests/delveHunters.test.ts
+++ b/src/tests/delveHunters.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect } from "vitest";
+import { roamMoveChance, spawnHunters, tickHunters } from "../game/delve/hunters";
+import type { RoomAdjacency } from "../game/delve/noise";
+import { createRng } from "../game/rng";
+import type { Direction, Hunter, NoiseEvent } from "../game/delve/types";
+
+// Line graph: entrance - r1 - r2 - r3 - r4
+const ROOM_ORDER = ["entrance", "r1", "r2", "r3", "r4"];
+const line: RoomAdjacency = {
+  entrance: ["r1"],
+  r1: ["entrance", "r2"],
+  r2: ["r1", "r3"],
+  r3: ["r2", "r4"],
+  r4: ["r3"]
+};
+
+function directionOf(fromRoomId: string, toRoomId: string): Direction | undefined {
+  const fromIdx = ROOM_ORDER.indexOf(fromRoomId);
+  const toIdx = ROOM_ORDER.indexOf(toRoomId);
+  if (fromIdx === -1 || toIdx === -1) return undefined;
+  return toIdx > fromIdx ? "east" : "west";
+}
+
+function hunter(overrides: Partial<Hunter> = {}): Hunter {
+  return { id: "h1", enemyId: "goblin", roomId: "r2", state: "dormant", ...overrides };
+}
+
+describe("delve hunters", () => {
+  describe("spawnHunters", () => {
+    it("spawns a count within the budget, capped by eligible rooms", () => {
+      const rng = createRng("spawn-1");
+      const hunters = spawnHunters({
+        floor: 1,
+        rng,
+        budget: { min: 4, max: 6 },
+        eligibleRoomIds: ["a", "b", "c", "d", "e", "f"],
+        enemyPool: ["goblin", "rat"]
+      });
+      expect(hunters.length).toBeGreaterThanOrEqual(4);
+      expect(hunters.length).toBeLessThanOrEqual(6);
+      const uniqueRooms = new Set(hunters.map(h => h.roomId));
+      expect(uniqueRooms.size).toBe(hunters.length);
+    });
+
+    it("never spawns more hunters than eligible rooms", () => {
+      const rng = createRng("spawn-2");
+      const hunters = spawnHunters({
+        floor: 1,
+        rng,
+        budget: { min: 4, max: 6 },
+        eligibleRoomIds: ["a", "b"],
+        enemyPool: ["goblin"]
+      });
+      expect(hunters.length).toBeLessThanOrEqual(2);
+    });
+
+    it("all hunters start dormant and draw enemyId from the pool", () => {
+      const rng = createRng("spawn-3");
+      const hunters = spawnHunters({
+        floor: 1,
+        rng,
+        budget: { min: 3, max: 3 },
+        eligibleRoomIds: ["a", "b", "c"],
+        enemyPool: ["goblin", "rat"]
+      });
+      for (const h of hunters) {
+        expect(h.state).toBe("dormant");
+        expect(["goblin", "rat"]).toContain(h.enemyId);
+      }
+    });
+
+    it("returns nothing when there are no eligible rooms", () => {
+      const rng = createRng("spawn-4");
+      const hunters = spawnHunters({
+        floor: 1,
+        rng,
+        budget: { min: 4, max: 6 },
+        eligibleRoomIds: [],
+        enemyPool: ["goblin"]
+      });
+      expect(hunters).toEqual([]);
+    });
+
+    it("is deterministic for a fixed seed", () => {
+      const opts = {
+        floor: 1,
+        budget: { min: 4, max: 6 },
+        eligibleRoomIds: ["a", "b", "c", "d", "e", "f"],
+        enemyPool: ["goblin", "rat", "ooze"]
+      };
+      const a = spawnHunters({ ...opts, rng: createRng("fixed-seed") });
+      const b = spawnHunters({ ...opts, rng: createRng("fixed-seed") });
+      expect(a.map(h => ({ ...h }))).toEqual(b.map(h => ({ ...h })));
+    });
+  });
+
+  describe("tickHunters state transitions", () => {
+    it("dormant hunter stays put with no noise", () => {
+      const rng = createRng("tick-dormant");
+      const { hunters } = tickHunters({
+        hunters: [hunter({ state: "dormant", roomId: "r2" })],
+        adjacency: line,
+        playerRoomId: "entrance",
+        noises: [],
+        alertnessLevel: 0,
+        rng,
+        directionOf
+      });
+      expect(hunters[0]).toEqual(hunter({ state: "dormant", roomId: "r2" }));
+    });
+
+    it("dormant hunter becomes drawn when hearing a distant noise", () => {
+      const rng = createRng("tick-draw");
+      const noise: NoiseEvent = { roomId: "entrance", loudness: 4, cause: "flee" };
+      const { hunters } = tickHunters({
+        hunters: [hunter({ state: "dormant", roomId: "r4" })], // distance 4 from entrance
+        adjacency: line,
+        playerRoomId: "entrance",
+        noises: [noise],
+        alertnessLevel: 0,
+        rng,
+        directionOf
+      });
+      expect(hunters[0]!.state).toBe("drawn");
+      expect(hunters[0]!.heardAt).toBe("entrance");
+      // Wakes up but doesn't move on the same tick it wakes.
+      expect(hunters[0]!.roomId).toBe("r4");
+    });
+
+    it("drawn hunter steps toward the heard room each tick and arrives", () => {
+      const rng = createRng("tick-drawn-step");
+      let hunters: Hunter[] = [hunter({ state: "drawn", roomId: "r4", heardAt: "entrance" })];
+
+      // Step 1: r4 -> r3
+      ({ hunters } = tickHunters({
+        hunters, adjacency: line, playerRoomId: "somewhereElse", noises: [], alertnessLevel: 0, rng, directionOf
+      }));
+      expect(hunters[0]!.roomId).toBe("r3");
+      expect(hunters[0]!.state).toBe("drawn");
+
+      // Step 2: r3 -> r2
+      ({ hunters } = tickHunters({
+        hunters, adjacency: line, playerRoomId: "somewhereElse", noises: [], alertnessLevel: 0, rng, directionOf
+      }));
+      expect(hunters[0]!.roomId).toBe("r2");
+
+      // Step 3: r2 -> r1
+      ({ hunters } = tickHunters({
+        hunters, adjacency: line, playerRoomId: "somewhereElse", noises: [], alertnessLevel: 0, rng, directionOf
+      }));
+      expect(hunters[0]!.roomId).toBe("r1");
+
+      // Step 4: r1 -> entrance, arrives, becomes roaming
+      ({ hunters } = tickHunters({
+        hunters, adjacency: line, playerRoomId: "somewhereElse", noises: [], alertnessLevel: 0, rng, directionOf
+      }));
+      expect(hunters[0]!.roomId).toBe("entrance");
+      expect(hunters[0]!.state).toBe("roaming");
+      expect(hunters[0]!.heardAt).toBeUndefined();
+    });
+
+    it("hunter becomes hunting on hearing noise within 2 rooms and converges on the player", () => {
+      const rng = createRng("tick-hunt-hear");
+      const noise: NoiseEvent = { roomId: "entrance", loudness: 4, cause: "flee" };
+      const { hunters, contacts } = tickHunters({
+        hunters: [hunter({ state: "roaming", roomId: "r2" })], // distance 2 from entrance
+        adjacency: line,
+        playerRoomId: "entrance",
+        noises: [noise],
+        alertnessLevel: 0,
+        rng,
+        directionOf
+      });
+      expect(hunters[0]!.state).toBe("hunting");
+      expect(hunters[0]!.roomId).toBe("r1"); // stepped toward player
+      expect(contacts).toEqual([]);
+    });
+
+    it("hunter becomes hunting on sight when in the same room as the player", () => {
+      const rng = createRng("tick-hunt-sight-same");
+      const { hunters, contacts } = tickHunters({
+        hunters: [hunter({ state: "roaming", roomId: "entrance" })],
+        adjacency: line,
+        playerRoomId: "entrance",
+        noises: [],
+        alertnessLevel: 0,
+        rng,
+        directionOf
+      });
+      expect(hunters[0]!.state).toBe("hunting");
+      expect(contacts).toEqual(["h1"]);
+    });
+
+    it("hunter becomes hunting on sight when adjacent and alertness >= 3", () => {
+      const rng = createRng("tick-hunt-sight-adj");
+      const { hunters } = tickHunters({
+        hunters: [hunter({ state: "roaming", roomId: "r1" })],
+        adjacency: line,
+        playerRoomId: "entrance",
+        noises: [],
+        alertnessLevel: 3,
+        rng,
+        directionOf
+      });
+      expect(hunters[0]!.state).toBe("hunting");
+    });
+
+    it("does not trigger sight-based hunting when adjacent but alertness is below 3", () => {
+      const rng = createRng("tick-hunt-sight-low-alert");
+      const { hunters } = tickHunters({
+        hunters: [hunter({ state: "roaming", roomId: "r1" })],
+        adjacency: line,
+        playerRoomId: "entrance",
+        noises: [],
+        alertnessLevel: 2,
+        rng,
+        directionOf
+      });
+      expect(hunters[0]!.state).not.toBe("hunting");
+    });
+
+    it("hunting hunter keeps converging every tick regardless of noise", () => {
+      const rng = createRng("tick-hunting-sticky");
+      let hunters: Hunter[] = [hunter({ state: "hunting", roomId: "r3" })];
+      ({ hunters } = tickHunters({
+        hunters, adjacency: line, playerRoomId: "entrance", noises: [], alertnessLevel: 0, rng, directionOf
+      }));
+      expect(hunters[0]!.roomId).toBe("r2");
+      expect(hunters[0]!.state).toBe("hunting");
+    });
+
+    it("reports contacts for hunters that end the tick in the player's room", () => {
+      const rng = createRng("tick-contact");
+      const { contacts } = tickHunters({
+        hunters: [hunter({ id: "h9", state: "hunting", roomId: "r1" })],
+        adjacency: line,
+        playerRoomId: "entrance",
+        noises: [],
+        alertnessLevel: 0,
+        rng,
+        directionOf
+      });
+      expect(contacts).toEqual(["h9"]);
+    });
+  });
+
+  describe("tickHunters signals", () => {
+    it("signals hunters within distance 2, direction 'here' at distance 0", () => {
+      const rng = createRng("signal-here");
+      const { signals } = tickHunters({
+        hunters: [hunter({ id: "h1", state: "hunting", roomId: "entrance" })],
+        adjacency: line,
+        playerRoomId: "r1", // hunter steps to r1 == player room this tick
+        noises: [],
+        alertnessLevel: 0,
+        rng,
+        directionOf
+      });
+      const signal = signals.find(s => s.hunterId === "h1")!;
+      expect(signal.distance).toBe(0);
+      expect(signal.direction).toBe("here");
+    });
+
+    it("derives direction from the first BFS step at distance 1", () => {
+      const rng = createRng("signal-dir");
+      const { signals } = tickHunters({
+        hunters: [hunter({ id: "h1", state: "dormant", roomId: "r2" })],
+        adjacency: line,
+        playerRoomId: "r1",
+        noises: [],
+        alertnessLevel: 0,
+        rng,
+        directionOf
+      });
+      const signal = signals.find(s => s.hunterId === "h1")!;
+      expect(signal.distance).toBe(1);
+      expect(signal.direction).toBe("east"); // r1 -> r2 is toward higher index
+    });
+
+    it("excludes hunters farther than distance 2", () => {
+      const rng = createRng("signal-far");
+      const { signals } = tickHunters({
+        hunters: [hunter({ id: "h1", state: "dormant", roomId: "r4" })],
+        adjacency: line,
+        playerRoomId: "entrance",
+        noises: [],
+        alertnessLevel: 0,
+        rng,
+        directionOf
+      });
+      expect(signals.find(s => s.hunterId === "h1")).toBeUndefined();
+    });
+  });
+
+  describe("roamMoveChance", () => {
+    it("is 0.5 at alertness 0", () => {
+      expect(roamMoveChance(0)).toBeCloseTo(0.5);
+    });
+
+    it("saturates at 0.8 at high alertness", () => {
+      expect(roamMoveChance(5)).toBeCloseTo(0.8);
+      expect(roamMoveChance(10)).toBeCloseTo(0.8);
+    });
+
+    it("increases monotonically with alertness", () => {
+      expect(roamMoveChance(3)).toBeGreaterThan(roamMoveChance(1));
+    });
+  });
+
+  describe("determinism", () => {
+    it("tickHunters produces identical output for a fixed seed and identical inputs", () => {
+      const noise: NoiseEvent = { roomId: "r2", loudness: 2, cause: "search" };
+      const baseHunters = [
+        hunter({ id: "h1", state: "roaming", roomId: "r3" }),
+        hunter({ id: "h2", state: "dormant", roomId: "r4" })
+      ];
+      const run = () =>
+        tickHunters({
+          hunters: baseHunters.map(h => ({ ...h })),
+          adjacency: line,
+          playerRoomId: "r2",
+          noises: [noise],
+          alertnessLevel: 1,
+          rng: createRng("determinism-seed"),
+          directionOf
+        });
+      const resultA = run();
+      const resultB = run();
+      expect(resultA).toEqual(resultB);
+    });
+
+    it("roaming random-walk is reproducible for a fixed seed", () => {
+      const run = () =>
+        tickHunters({
+          hunters: [hunter({ id: "h1", state: "roaming", roomId: "r2" })],
+          adjacency: line,
+          playerRoomId: "somewhereElse",
+          noises: [],
+          alertnessLevel: 4,
+          rng: createRng("roam-seed"),
+          directionOf
+        });
+      const resultA = run();
+      const resultB = run();
+      expect(resultA).toEqual(resultB);
+    });
+  });
+});

--- a/src/tests/delveLamp.test.ts
+++ b/src/tests/delveLamp.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { OIL_COSTS, getLightState, refillFromFlask, spendOil } from "../game/delve/lamp";
+import type { LampState } from "../game/delve/types";
+
+function lamp(overrides: Partial<LampState> = {}): LampState {
+  return { oil: 20, capacity: 20, flasksPacked: 0, ...overrides };
+}
+
+describe("delve lamp", () => {
+  it("spends the correct oil cost per action", () => {
+    expect(spendOil(lamp({ oil: 20 }), "move").oil).toBe(19);
+    expect(spendOil(lamp({ oil: 20 }), "search").oil).toBe(18);
+    expect(spendOil(lamp({ oil: 20 }), "listen").oil).toBe(19);
+    expect(spendOil(lamp({ oil: 20 }), "encounterBeat").oil).toBe(19);
+    expect(spendOil(lamp({ oil: 20 }), "disarm").oil).toBe(18);
+    expect(spendOil(lamp({ oil: 20 }), "crank").oil).toBe(19);
+    expect(spendOil(lamp({ oil: 20 }), "consultMap").oil).toBe(19);
+  });
+
+  it("exposes the full cost table", () => {
+    expect(OIL_COSTS).toEqual({
+      move: 1,
+      search: 2,
+      listen: 1,
+      encounterBeat: 1,
+      disarm: 2,
+      crank: 1,
+      consultMap: 1
+    });
+  });
+
+  it("floors oil at zero instead of going negative", () => {
+    const result = spendOil(lamp({ oil: 1 }), "search");
+    expect(result.oil).toBe(0);
+  });
+
+  it("does not mutate the input lamp", () => {
+    const original = lamp({ oil: 20 });
+    const result = spendOil(original, "move");
+    expect(original.oil).toBe(20);
+    expect(result).not.toBe(original);
+  });
+
+  it("refills to capacity and consumes a flask", () => {
+    const result = refillFromFlask(lamp({ oil: 3, capacity: 20, flasksPacked: 2 }));
+    expect(result.oil).toBe(20);
+    expect(result.flasksPacked).toBe(1);
+  });
+
+  it("refill is a no-op when no flasks are packed", () => {
+    const before = lamp({ oil: 3, capacity: 20, flasksPacked: 0 });
+    const result = refillFromFlask(before);
+    expect(result).toEqual(before);
+  });
+
+  describe("getLightState", () => {
+    it("is bright above the dim threshold", () => {
+      expect(getLightState(lamp({ oil: 20, capacity: 20 }))).toBe("bright");
+      expect(getLightState(lamp({ oil: 6, capacity: 20 }))).toBe("bright"); // > 25%
+    });
+
+    it("is dim at exactly 25% of capacity", () => {
+      expect(getLightState(lamp({ oil: 5, capacity: 20 }))).toBe("dim");
+    });
+
+    it("is dim just above zero", () => {
+      expect(getLightState(lamp({ oil: 1, capacity: 20 }))).toBe("dim");
+    });
+
+    it("is dark at exactly zero oil", () => {
+      expect(getLightState(lamp({ oil: 0, capacity: 20 }))).toBe("dark");
+    });
+
+    it("handles a non-default capacity", () => {
+      expect(getLightState(lamp({ oil: 10, capacity: 40 }))).toBe("dim"); // == 25%
+      expect(getLightState(lamp({ oil: 11, capacity: 40 }))).toBe("bright");
+    });
+  });
+});

--- a/src/tests/delveNoise.test.ts
+++ b/src/tests/delveNoise.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  NOISE_LOUDNESS,
+  bfsDistances,
+  bfsPath,
+  emitNoise,
+  graphDistance,
+  hunterHears,
+  moveNoiseLoudness,
+  type RoomAdjacency
+} from "../game/delve/noise";
+import type { NoiseEvent } from "../game/delve/types";
+
+// A simple line graph: a - b - c - d - e
+const line: RoomAdjacency = {
+  a: ["b"],
+  b: ["a", "c"],
+  c: ["b", "d"],
+  d: ["c", "e"],
+  e: ["d"]
+};
+
+// A branching graph with an isolated room.
+const branch: RoomAdjacency = {
+  hub: ["north", "south"],
+  north: ["hub"],
+  south: ["hub"],
+  island: []
+};
+
+function noise(overrides: Partial<NoiseEvent> = {}): NoiseEvent {
+  return { roomId: "a", loudness: 2, cause: "search", ...overrides };
+}
+
+describe("delve noise", () => {
+  it("exposes fixed loudness for non-move causes", () => {
+    expect(NOISE_LOUDNESS).toEqual({
+      search: 2,
+      fightBeat: 3,
+      lockwork: 3,
+      flee: 4,
+      crank: 4
+    });
+  });
+
+  describe("moveNoiseLoudness", () => {
+    it("is 1 by default", () => {
+      expect(moveNoiseLoudness({ packRatio: 0.2, lightState: "bright" })).toBe(1);
+    });
+
+    it("adds 1 for an overloaded pack", () => {
+      expect(moveNoiseLoudness({ packRatio: 0.61, lightState: "bright" })).toBe(2);
+    });
+
+    it("adds 1 more in the dark", () => {
+      expect(moveNoiseLoudness({ packRatio: 0.61, lightState: "dark" })).toBe(3);
+    });
+
+    it("stacks dark penalty even with a light pack", () => {
+      expect(moveNoiseLoudness({ packRatio: 0.1, lightState: "dark" })).toBe(2);
+    });
+
+    it("does not add the pack penalty at exactly 60%", () => {
+      expect(moveNoiseLoudness({ packRatio: 0.6, lightState: "bright" })).toBe(1);
+    });
+  });
+
+  describe("bfsDistances / graphDistance", () => {
+    it("computes distance 0 for the origin room", () => {
+      const distances = bfsDistances(line, "a");
+      expect(distances.a).toBe(0);
+    });
+
+    it("computes correct distances along a line graph", () => {
+      const distances = bfsDistances(line, "a");
+      expect(distances).toEqual({ a: 0, b: 1, c: 2, d: 3, e: 4 });
+    });
+
+    it("graphDistance matches bfsDistances", () => {
+      expect(graphDistance(line, "a", "d")).toBe(3);
+      expect(graphDistance(line, "c", "c")).toBe(0);
+    });
+
+    it("returns undefined distance for an unreachable room", () => {
+      expect(graphDistance(branch, "hub", "island")).toBeUndefined();
+    });
+  });
+
+  describe("bfsPath", () => {
+    it("returns a single-room path for the same room", () => {
+      expect(bfsPath(line, "b", "b")).toEqual(["b"]);
+    });
+
+    it("returns the shortest path along a line", () => {
+      expect(bfsPath(line, "a", "e")).toEqual(["a", "b", "c", "d", "e"]);
+    });
+
+    it("returns undefined for an unreachable room", () => {
+      expect(bfsPath(branch, "hub", "island")).toBeUndefined();
+    });
+  });
+
+  describe("emitNoise", () => {
+    it("passes the event through unchanged", () => {
+      const event = noise({ roomId: "c", loudness: 3, cause: "flee" });
+      expect(emitNoise(event)).toEqual(event);
+    });
+  });
+
+  describe("hunterHears", () => {
+    it("hears when loudness >= distance", () => {
+      const event = noise({ roomId: "a", loudness: 2 });
+      expect(hunterHears(event, "a", line)).toBe(true); // distance 0
+      expect(hunterHears(event, "b", line)).toBe(true); // distance 1
+      expect(hunterHears(event, "c", line)).toBe(true); // distance 2, equal
+    });
+
+    it("does not hear when loudness < distance", () => {
+      const event = noise({ roomId: "a", loudness: 2 });
+      expect(hunterHears(event, "d", line)).toBe(false); // distance 3
+    });
+
+    it("never hears across unreachable rooms", () => {
+      const event = noise({ roomId: "hub", loudness: 99 });
+      expect(hunterHears(event, "island", branch)).toBe(false);
+    });
+  });
+});

--- a/src/tests/delvePlace.test.ts
+++ b/src/tests/delvePlace.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from "vitest";
+import { createRng } from "../game/rng";
+import { getPlace, validatePlace, buildAdjacency, populateFloor } from "../game/delve/place";
+import { GOBLIN_WARRENS } from "../game/delve/places/goblinWarrens";
+import type { Place, PlaceFloor, PlaceRoom } from "../game/delve/types";
+
+function room(partial: Partial<PlaceRoom> & { id: string }): PlaceRoom {
+  return {
+    id: partial.id,
+    name: partial.name ?? partial.id,
+    prose: partial.prose ?? ["A room."],
+    landmark: partial.landmark,
+    exits: partial.exits ?? [],
+    lootTableId: partial.lootTableId,
+    hunterSpawn: partial.hunterSpawn,
+    supplySpawn: partial.supplySpawn
+  };
+}
+
+function makePlace(floors: PlaceFloor[]): Place {
+  return { id: "test_place", name: "Test Place", biome: "goblinWarrens", floors };
+}
+
+function baseFloor(rooms: PlaceRoom[], overrides: Partial<PlaceFloor> = {}): PlaceFloor {
+  return {
+    floor: 1,
+    entranceRoomId: rooms[0]!.id,
+    rooms,
+    extracts: [{ id: "ex1", roomId: rooms[rooms.length - 1]!.id, label: "Out", condition: "alwaysOpen" }],
+    hunterBudget: { min: 1, max: 1 },
+    ...overrides
+  };
+}
+
+describe("validatePlace", () => {
+  it("accepts a small well-formed floor", () => {
+    const rooms = [
+      room({ id: "a", exits: [{ direction: "north", to: "b" }], hunterSpawn: true }),
+      room({ id: "b", exits: [{ direction: "south", to: "a" }] })
+    ];
+    const place = makePlace([baseFloor(rooms, { extracts: [{ id: "ex1", roomId: "b", label: "Out", condition: "alwaysOpen" }] })]);
+    expect(() => validatePlace(place)).not.toThrow();
+  });
+
+  it("throws when an exit points to an unknown room", () => {
+    const rooms = [
+      room({ id: "a", exits: [{ direction: "north", to: "ghost" }], hunterSpawn: true }),
+      room({ id: "b", exits: [] })
+    ];
+    const place = makePlace([baseFloor(rooms)]);
+    expect(() => validatePlace(place)).toThrow(/unknown room "ghost"/);
+  });
+
+  it("throws when an exit has no reciprocal and is not marked oneWay", () => {
+    const rooms = [
+      room({ id: "a", exits: [{ direction: "north", to: "b" }], hunterSpawn: true }),
+      room({ id: "b", exits: [] })
+    ];
+    const place = makePlace([baseFloor(rooms, { extracts: [{ id: "ex1", roomId: "b", label: "Out", condition: "alwaysOpen" }] })]);
+    expect(() => validatePlace(place)).toThrow(/no reciprocal exit/);
+  });
+
+  it("allows a oneWay exit with no reciprocal", () => {
+    const rooms = [
+      room({ id: "a", exits: [{ direction: "down", to: "b", oneWay: true }], hunterSpawn: true }),
+      room({ id: "b", exits: [] })
+    ];
+    const place = makePlace([baseFloor(rooms, { extracts: [{ id: "ex1", roomId: "b", label: "Out", condition: "alwaysOpen" }] })]);
+    expect(() => validatePlace(place)).not.toThrow();
+  });
+
+  it("throws when a room is unreachable from the entrance", () => {
+    const rooms = [
+      room({ id: "a", exits: [], hunterSpawn: true }),
+      room({ id: "b", exits: [] })
+    ];
+    const place = makePlace([baseFloor(rooms, { extracts: [{ id: "ex1", roomId: "a", label: "Out", condition: "alwaysOpen" }] })]);
+    expect(() => validatePlace(place)).toThrow(/not reachable/);
+  });
+
+  it("throws when a room has two exits in the same direction", () => {
+    const rooms = [
+      room({ id: "a", exits: [{ direction: "north", to: "b" }, { direction: "north", to: "c" }], hunterSpawn: true }),
+      room({ id: "b", exits: [{ direction: "south", to: "a" }] }),
+      room({ id: "c", exits: [{ direction: "south", to: "a" }] })
+    ];
+    const place = makePlace([baseFloor(rooms, { extracts: [{ id: "ex1", roomId: "b", label: "Out", condition: "alwaysOpen" }] })]);
+    expect(() => validatePlace(place)).toThrow(/more than one exit in direction "north"/);
+  });
+
+  it("throws when an extract references an unknown room", () => {
+    const rooms = [
+      room({ id: "a", exits: [{ direction: "north", to: "b" }], hunterSpawn: true }),
+      room({ id: "b", exits: [{ direction: "south", to: "a" }] })
+    ];
+    const place = makePlace([baseFloor(rooms, {
+      extracts: [{ id: "ex1", roomId: "ghost_room", label: "Out", condition: "alwaysOpen" }]
+    })]);
+    expect(() => validatePlace(place)).toThrow(/extract "ex1" references unknown room/);
+  });
+
+  it("throws when entranceRoomId does not exist", () => {
+    const rooms = [
+      room({ id: "a", exits: [{ direction: "north", to: "b" }], hunterSpawn: true }),
+      room({ id: "b", exits: [{ direction: "south", to: "a" }] })
+    ];
+    const place = makePlace([baseFloor(rooms, {
+      entranceRoomId: "nope",
+      extracts: [{ id: "ex1", roomId: "b", label: "Out", condition: "alwaysOpen" }]
+    })]);
+    expect(() => validatePlace(place)).toThrow(/entranceRoomId "nope" does not exist/);
+  });
+
+  it("throws when hunterSpawn rooms are fewer than hunterBudget.max", () => {
+    const rooms = [
+      room({ id: "a", exits: [{ direction: "north", to: "b" }] }),
+      room({ id: "b", exits: [{ direction: "south", to: "a" }] })
+    ];
+    const place = makePlace([baseFloor(rooms, {
+      hunterBudget: { min: 1, max: 3 },
+      extracts: [{ id: "ex1", roomId: "b", label: "Out", condition: "alwaysOpen" }]
+    })]);
+    expect(() => validatePlace(place)).toThrow(/hunterSpawn rooms/);
+  });
+
+  it("throws when a floor has no extracts at all", () => {
+    const rooms = [
+      room({ id: "a", exits: [{ direction: "north", to: "b" }], hunterSpawn: true }),
+      room({ id: "b", exits: [{ direction: "south", to: "a" }] })
+    ];
+    const place = makePlace([baseFloor(rooms, { extracts: [] })]);
+    expect(() => validatePlace(place)).toThrow(/has no extracts/);
+  });
+});
+
+describe("buildAdjacency", () => {
+  it("honors oneWay exits (no reverse edge)", () => {
+    const rooms = [
+      room({ id: "a", exits: [{ direction: "down", to: "b", oneWay: true }] }),
+      room({ id: "b", exits: [{ direction: "north", to: "c" }] }),
+      room({ id: "c", exits: [{ direction: "south", to: "b" }] })
+    ];
+    const floor = baseFloor(rooms);
+    const adjacency = buildAdjacency(floor);
+    expect(adjacency["a"]).toEqual(["b"]);
+    expect(adjacency["b"]).toEqual(["c"]);
+    expect(adjacency["b"]).not.toContain("a");
+  });
+});
+
+describe("goblinWarrens place", () => {
+  it("passes validation", () => {
+    expect(() => validatePlace(GOBLIN_WARRENS)).not.toThrow();
+  });
+
+  it("is retrievable from the registry", () => {
+    expect(getPlace("goblinWarrens")).toBe(GOBLIN_WARRENS);
+    expect(() => getPlace("nope")).toThrow(/Unknown place/);
+  });
+
+  it("has two floors of 25-30 rooms each with the required extracts", () => {
+    expect(GOBLIN_WARRENS.floors).toHaveLength(2);
+    for (const floor of GOBLIN_WARRENS.floors) {
+      expect(floor.rooms.length).toBeGreaterThanOrEqual(25);
+      expect(floor.rooms.length).toBeLessThanOrEqual(30);
+    }
+    const floor1 = GOBLIN_WARRENS.floors[0]!;
+    const extractLabels = floor1.extracts.map(e => e.label).sort();
+    expect(extractLabels).toEqual(["The flooded stair", "The rope winch", "The way you came"].sort());
+    const barredDoor = floor1.extracts.find(e => e.label === "The way you came")!;
+    expect(barredDoor.condition).toBe("closesAtAlertness");
+    expect(barredDoor.alertnessLevel).toBe(3);
+    expect(barredDoor.roomId).toBe(floor1.entranceRoomId);
+    const flooded = floor1.extracts.find(e => e.label === "The flooded stair")!;
+    expect(flooded.condition).toBe("waterClock");
+    const winch = floor1.extracts.find(e => e.label === "The rope winch")!;
+    expect(winch.condition).toBe("cranked");
+    expect(winch.cranksRequired).toBe(3);
+  });
+
+  it("has at least 5 landmark rooms per floor", () => {
+    for (const floor of GOBLIN_WARRENS.floors) {
+      const landmarks = floor.rooms.filter(r => r.landmark);
+      expect(landmarks.length).toBeGreaterThanOrEqual(5);
+    }
+  });
+
+  it("has at least 8 hunterSpawn and 4 supplySpawn rooms per floor", () => {
+    for (const floor of GOBLIN_WARRENS.floors) {
+      expect(floor.rooms.filter(r => r.hunterSpawn).length).toBeGreaterThanOrEqual(8);
+      expect(floor.rooms.filter(r => r.supplySpawn).length).toBeGreaterThanOrEqual(4);
+    }
+  });
+
+  it("has at least two oneWay shortcuts per floor", () => {
+    for (const floor of GOBLIN_WARRENS.floors) {
+      const oneWayCount = floor.rooms.flatMap(r => r.exits).filter(e => e.oneWay).length;
+      expect(oneWayCount).toBeGreaterThanOrEqual(2);
+    }
+  });
+});
+
+describe("populateFloor", () => {
+  const floor = GOBLIN_WARRENS.floors[0]!;
+
+  it("is deterministic for the same seed", () => {
+    const a = populateFloor({ floor, rng: createRng("delve-seed-1"), tier: 1 });
+    const b = populateFloor({ floor, rng: createRng("delve-seed-1"), tier: 1 });
+    expect(a).toEqual(b);
+  });
+
+  it("differs for different seeds (with overwhelming likelihood)", () => {
+    const a = populateFloor({ floor, rng: createRng("delve-seed-A"), tier: 1 });
+    const b = populateFloor({ floor, rng: createRng("delve-seed-B"), tier: 1 });
+    expect(a).not.toEqual(b);
+  });
+
+  it("picks one prose variant per room from the room's own pool", () => {
+    const result = populateFloor({ floor, rng: createRng("prose-check"), tier: 1 });
+    for (const room of floor.rooms) {
+      expect(room.prose).toContain(result.roomProse[room.id]);
+    }
+  });
+
+  it("respects hunterBudget when choosing hunter spawn rooms", () => {
+    for (const seed of ["s1", "s2", "s3", "s4", "s5"]) {
+      const result = populateFloor({ floor, rng: createRng(seed), tier: 1 });
+      expect(result.hunterSpawnRoomIds.length).toBeGreaterThanOrEqual(floor.hunterBudget.min);
+      expect(result.hunterSpawnRoomIds.length).toBeLessThanOrEqual(floor.hunterBudget.max);
+      for (const roomId of result.hunterSpawnRoomIds) {
+        const r = floor.rooms.find(fr => fr.id === roomId)!;
+        expect(r.hunterSpawn).toBe(true);
+      }
+    }
+  });
+
+  it("also respects budgets and pools on floor 2 (not just floor 1)", () => {
+    const floor2 = GOBLIN_WARRENS.floors[1]!;
+    for (const seed of ["f2-s1", "f2-s2", "f2-s3"]) {
+      const result = populateFloor({ floor: floor2, rng: createRng(seed), tier: 1 });
+      expect(result.hunterSpawnRoomIds.length).toBeGreaterThanOrEqual(floor2.hunterBudget.min);
+      expect(result.hunterSpawnRoomIds.length).toBeLessThanOrEqual(floor2.hunterBudget.max);
+      for (const roomId of result.hunterSpawnRoomIds) {
+        expect(floor2.rooms.find(r => r.id === roomId)!.hunterSpawn).toBe(true);
+      }
+      expect(result.supplyRoomIds.length).toBeGreaterThanOrEqual(2);
+      expect(result.supplyRoomIds.length).toBeLessThanOrEqual(3);
+      for (const { roomId } of result.supplyRoomIds) {
+        expect(floor2.rooms.find(r => r.id === roomId)!.supplySpawn).toBe(true);
+      }
+    }
+    const a = populateFloor({ floor: floor2, rng: createRng("f2-determinism"), tier: 1 });
+    const b = populateFloor({ floor: floor2, rng: createRng("f2-determinism"), tier: 1 });
+    expect(a).toEqual(b);
+  });
+
+  it("places 2-3 supply caches only in supplySpawn rooms", () => {
+    for (const seed of ["s1", "s2", "s3", "s4", "s5"]) {
+      const result = populateFloor({ floor, rng: createRng(seed), tier: 1 });
+      expect(result.supplyRoomIds.length).toBeGreaterThanOrEqual(2);
+      expect(result.supplyRoomIds.length).toBeLessThanOrEqual(3);
+      for (const { roomId, kind } of result.supplyRoomIds) {
+        const r = floor.rooms.find(fr => fr.id === roomId)!;
+        expect(r.supplySpawn).toBe(true);
+        expect(["oilFlask", "rations"]).toContain(kind);
+      }
+    }
+  });
+
+  it("marks every room with a lootTableId as a loot room", () => {
+    const result = populateFloor({ floor, rng: createRng("loot-check"), tier: 1 });
+    const expected = floor.rooms.filter(r => r.lootTableId).map(r => r.id).sort();
+    expect(result.lootRoomIds.slice().sort()).toEqual(expected);
+  });
+
+  it("only rolls doorOverrides for exits with a doorStates pool, and never for open", () => {
+    const result = populateFloor({ floor, rng: createRng("door-check"), tier: 1 });
+    const exitsWithPools = new Set<string>();
+    for (const room of floor.rooms) {
+      for (const exit of room.exits) {
+        if (exit.doorStates && exit.doorStates.length > 0) {
+          exitsWithPools.add(`${room.id}:${exit.direction}`);
+        }
+      }
+    }
+    for (const key of Object.keys(result.doorOverrides)) {
+      expect(exitsWithPools.has(key)).toBe(true);
+      expect(result.doorOverrides[key]).not.toBe("open");
+    }
+  });
+});

--- a/src/tests/delveRun.test.ts
+++ b/src/tests/delveRun.test.ts
@@ -1,0 +1,937 @@
+import { describe, expect, it } from "vitest";
+import { applyDelveAction, createDelveRun, DEFAULT_WATER_CLOCK } from "../game/delve/delveRun";
+import { buildAdjacency, getPlace } from "../game/delve/place";
+import { getLightState } from "../game/delve/lamp";
+import { bfsDistances, bfsPath } from "../game/delve/noise";
+import type {
+  DelveAction,
+  DelveActionResult,
+  DelveRunDeps,
+  DelveRunEvent,
+  DelveRunState,
+  Direction,
+  PlaceFloor
+} from "../game/delve/types";
+import { CharacterCreationService, createEmptyDraft } from "../game/characterCreation";
+import { getThreatLevelFromPoints } from "../game/threat";
+import { THREAT_RULES } from "../game/constants";
+import type { Character, ItemInstance } from "../game/types";
+
+const PLACE_ID = "goblinWarrens";
+const HUNTING_POINTS = THREAT_RULES.thresholds.find(t => t.label === "Hunting")!.minPoints;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function buildCharacter(seed: string): Character {
+  let draft = createEmptyDraft(seed);
+  draft = CharacterCreationService.setName(draft, "Delver");
+  draft = CharacterCreationService.selectAncestry(draft, "human");
+  draft = CharacterCreationService.selectClass(draft, "warrior");
+  draft = CharacterCreationService.rollAllAbilityScores(draft);
+  draft = CharacterCreationService.autoAssignScoresForClass(draft);
+  draft = CharacterCreationService.chooseStarterKit(draft, "warrior_sword_shield");
+  return CharacterCreationService.finalizeCharacter(draft).character;
+}
+
+interface Harness {
+  state: DelveRunState;
+  character: Character;
+  carried: ItemInstance[];
+  events: DelveRunEvent[];
+}
+
+function makeHarness(seed: string, runOverrides: Partial<Parameters<typeof createDelveRun>[0]> = {}): Harness {
+  return {
+    state: createDelveRun({ placeId: PLACE_ID, seed, flasksPacked: 1, ...runOverrides }),
+    character: buildCharacter(seed),
+    carried: [],
+    events: []
+  };
+}
+
+function depsOf(h: Harness): DelveRunDeps {
+  return {
+    character: h.character,
+    carriedItems: h.carried,
+    carriedWeight: h.carried.reduce((sum, i) => sum + i.weight * i.quantity, 0),
+    carryCapacity: h.character.derivedStats.carryCapacity
+  };
+}
+
+/** Apply an action and fold hp/inventory events back into the harness, the way the store would. */
+function act(h: Harness, action: DelveAction): DelveActionResult {
+  const result = applyDelveAction(h.state, action, depsOf(h));
+  h.state = result.state;
+  for (const event of result.events) {
+    h.events.push(event);
+    if (event.kind === "hpDelta") {
+      h.character = {
+        ...h.character,
+        hp: Math.min(h.character.maxHp, h.character.hp + event.amount)
+      };
+    } else if (event.kind === "itemsTaken") {
+      h.carried = [...h.carried, ...event.items];
+    } else if (event.kind === "flaskConsumed") {
+      const idx = h.carried.findIndex(i => i.tags?.includes("oilFlask"));
+      if (idx >= 0) h.carried = h.carried.filter((_, i) => i !== idx);
+    } else if (event.kind === "itemConsumed") {
+      const idx = h.carried.findIndex(i => i.tags?.includes(event.tag));
+      if (idx >= 0) h.carried = h.carried.filter((_, i) => i !== idx);
+    }
+  }
+  return result;
+}
+
+/** Resolve any active encounter with fight beats (press), up to a safety cap. */
+function fightItOut(h: Harness): void {
+  for (let beat = 0; beat < 12 && h.state.activeEncounter && h.state.status === "active"; beat++) {
+    act(h, { type: "fightBeat", stance: "press" });
+  }
+}
+
+function floor1(): PlaceFloor {
+  return getPlace(PLACE_ID).floors[0]!;
+}
+
+function directionBetween(floor: PlaceFloor, from: string, to: string): Direction {
+  const direction = floor.rooms.find(r => r.id === from)?.exits.find(e => e.to === to)?.direction;
+  if (!direction) throw new Error(`No exit ${from} -> ${to}`);
+  return direction;
+}
+
+/** Walk toward a room, resolving encounters and locked doors along the way. */
+function walkTo(h: Harness, targetRoomId: string, maxSteps = 60): void {
+  const floor = getPlace(PLACE_ID).floors.find(f => f.floor === h.state.floor)!;
+  const adjacency = buildAdjacency(floor);
+  for (let step = 0; step < maxSteps; step++) {
+    if (h.state.status !== "active") return;
+    if (h.state.activeEncounter) {
+      fightItOut(h);
+      continue;
+    }
+    if (h.state.currentRoomId === targetRoomId) return;
+    const path = bfsPath(adjacency, h.state.currentRoomId, targetRoomId);
+    if (!path || path.length < 2) throw new Error(`No path ${h.state.currentRoomId} -> ${targetRoomId}`);
+    act(h, { type: "move", direction: directionBetween(floor, h.state.currentRoomId, path[1]!) });
+  }
+  throw new Error(`walkTo(${targetRoomId}) did not arrive in ${maxSteps} steps`);
+}
+
+function narrativeText(result: DelveActionResult): string {
+  return result.narrative.map(n => n.text).join(" | ");
+}
+
+// ---------------------------------------------------------------------------
+// createDelveRun
+// ---------------------------------------------------------------------------
+
+describe("createDelveRun", () => {
+  it("starts at the entrance with a populated floor and dormant hunters", () => {
+    const state = createDelveRun({ placeId: PLACE_ID, seed: "start-1" });
+    expect(state.currentRoomId).toBe("gullet");
+    expect(state.visitedRoomIds).toEqual(["gullet"]);
+    expect(state.status).toBe("active");
+    expect(state.lamp).toEqual({ oil: 20, capacity: 20, flasksPacked: 1 });
+    expect(state.waterClock).toBe(DEFAULT_WATER_CLOCK);
+    expect(state.alertness).toBe(0);
+
+    const budget = floor1().hunterBudget;
+    expect(state.hunters.length).toBeGreaterThanOrEqual(budget.min);
+    expect(state.hunters.length).toBeLessThanOrEqual(budget.max);
+    const spawnRooms = new Set(floor1().rooms.filter(r => r.hunterSpawn).map(r => r.id));
+    for (const hunter of state.hunters) {
+      expect(hunter.state).toBe("dormant");
+      expect(spawnRooms.has(hunter.roomId)).toBe(true);
+    }
+
+    // Entrance prose + one sense line per exit.
+    expect(state.narrative[0]!.kind).toBe("room");
+    expect(state.narrative[0]!.text).toContain("The Gullet");
+    const senseLines = state.narrative.filter(n => n.kind === "sense");
+    expect(senseLines.length).toBe(floor1().rooms.find(r => r.id === "gullet")!.exits.length);
+  });
+
+  it("chooses room prose variants and door overrides from the seed", () => {
+    const a = createDelveRun({ placeId: PLACE_ID, seed: "pop-a" });
+    const b = createDelveRun({ placeId: PLACE_ID, seed: "pop-a" });
+    expect(a.roomProse).toEqual(b.roomProse);
+    expect(a.doorOverrides).toEqual(b.doorOverrides);
+    expect(a.hunters).toEqual(b.hunters);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// move
+// ---------------------------------------------------------------------------
+
+describe("move", () => {
+  it("spends oil, emits move noise into alertness, ticks the water clock, and appends prose", () => {
+    const h = makeHarness("move-1");
+    const before = h.state;
+    const result = act(h, { type: "move", direction: "south" });
+    expect(h.state.currentRoomId).toBe("antechamber");
+    expect(h.state.cameFromRoomId).toBe("gullet");
+    expect(h.state.lamp.oil).toBe(before.lamp.oil - 1);
+    expect(h.state.alertness).toBe(before.alertness + 1); // light pack, bright lamp
+    expect(h.state.waterClock).toBe(before.waterClock - 1);
+    expect(result.narrative.some(n => n.kind === "room" && n.text.includes("Antechamber"))).toBe(true);
+    expect(result.narrative.some(n => n.kind === "sense")).toBe(true);
+  });
+
+  it("refuses a direction with no exit at no cost", () => {
+    const h = makeHarness("move-2");
+    const before = h.state;
+    const result = act(h, { type: "move", direction: "west" });
+    expect(h.state.currentRoomId).toBe("gullet");
+    expect(h.state.lamp.oil).toBe(before.lamp.oil);
+    expect(h.state.waterClock).toBe(before.waterClock);
+    expect(narrativeText(result)).toContain("no way west");
+  });
+
+  it("treats locked doors as lockwork: oil 2, noise 3, may fail, opens on success", () => {
+    const h = makeHarness("move-3");
+    h.state = { ...h.state, doorOverrides: { ...h.state.doorOverrides, "gullet:south": "locked" } };
+
+    let attempts = 0;
+    while (h.state.currentRoomId === "gullet" && attempts < 20) {
+      const before = h.state;
+      act(h, { type: "move", direction: "south" });
+      attempts++;
+      expect(h.state.lamp.oil).toBe(Math.max(0, before.lamp.oil - 2));
+      expect(h.state.alertness).toBe(before.alertness + 3);
+    }
+    expect(h.state.currentRoomId).toBe("antechamber");
+    expect(h.state.doorOverrides["gullet:south"]).toBeUndefined();
+  });
+
+  it("first visit uses the populated prose variant; revisits do not repeat it", () => {
+    const h = makeHarness("move-4");
+    const first = act(h, { type: "move", direction: "south" });
+    fightItOut(h);
+    const firstRoomLine = first.narrative.find(n => n.kind === "room");
+    expect(firstRoomLine!.text).toContain(h.state.roomProse["antechamber"]!);
+    if (h.state.status !== "active") return; // rare hunter ambush on this seed path
+    act(h, { type: "move", direction: "north" });
+    fightItOut(h);
+    if (h.state.status !== "active") return;
+    const back = act(h, { type: "move", direction: "south" });
+    const revisitLine = back.narrative.find(n => n.kind === "room");
+    expect(revisitLine!.text).toBe("Antechamber, again.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// search & loot
+// ---------------------------------------------------------------------------
+
+describe("search", () => {
+  it("rolls loot into pendingLoot for marked rooms and emits lootFound", () => {
+    const h = makeHarness("search-1");
+    walkTo(h, "trade_room");
+    expect(h.state.status).toBe("active");
+    expect(h.state.lootRoomIds).toContain("trade_room");
+
+    const before = h.state;
+    const result = act(h, { type: "search" });
+    expect(h.state.lamp.oil).toBe(before.lamp.oil - 2);
+    expect(h.state.alertness).toBe(before.alertness + 2);
+    const pool = h.state.pendingLoot["trade_room"];
+    expect(pool).toBeDefined();
+    expect(pool!.items.length).toBeGreaterThan(0);
+    expect(pool!.gold).toBeGreaterThan(0);
+    expect(result.events.some(e => e.kind === "lootFound")).toBe(true);
+    expect(h.state.searchedRoomIds).toContain("trade_room");
+  });
+
+  it("finds nothing on a second search of the same room", () => {
+    const h = makeHarness("search-2");
+    walkTo(h, "trade_room");
+    act(h, { type: "search" });
+    const poolBefore = h.state.pendingLoot["trade_room"];
+    const again = act(h, { type: "search" });
+    expect(narrativeText(again)).toContain("already turned this room over");
+    expect(h.state.pendingLoot["trade_room"]).toEqual(poolBefore);
+  });
+
+  it("supply caches yield oil flasks or rations as items", () => {
+    // Force a known cache so the test doesn't depend on the population roll.
+    const h = makeHarness("search-3");
+    walkTo(h, "antechamber");
+    h.state = {
+      ...h.state,
+      supplyCaches: [{ roomId: "antechamber", kind: "oilFlask", found: false }]
+    };
+    act(h, { type: "search" });
+    const pool = h.state.pendingLoot["antechamber"];
+    expect(pool!.items.some(i => i.tags?.includes("oilFlask"))).toBe(true);
+
+    const flasksBefore = h.state.lamp.flasksPacked;
+    act(h, { type: "takeAllLoot" });
+    expect(h.state.lamp.flasksPacked).toBe(flasksBefore + 1); // bagging a flask stocks the lamp
+    expect(h.carried.some(i => i.tags?.includes("oilFlask"))).toBe(true);
+  });
+});
+
+describe("loot actions", () => {
+  function harnessWithLoot(seed: string): Harness {
+    const h = makeHarness(seed);
+    h.state = { ...h.state, hunters: [] }; // keep the loot mechanics free of ambushes
+    walkTo(h, "trade_room");
+    act(h, { type: "search" });
+    expect(h.state.pendingLoot["trade_room"]).toBeDefined();
+    return h;
+  }
+
+  it("takeAllLoot moves what fits into the pack and emits itemsTaken; no oil, no noise, no tick", () => {
+    const h = harnessWithLoot("loot-1");
+    const before = h.state;
+    const pool = before.pendingLoot["trade_room"]!;
+    const result = act(h, { type: "takeAllLoot" });
+    expect(h.state.lamp.oil).toBe(before.lamp.oil);
+    expect(h.state.alertness).toBe(before.alertness);
+    expect(h.state.waterClock).toBe(before.waterClock);
+    const taken = result.events.find(e => e.kind === "itemsTaken");
+    expect(taken).toBeDefined();
+    if (taken?.kind === "itemsTaken") {
+      expect(taken.items.length).toBe(pool.items.length);
+      expect(taken.gold).toBe(pool.gold);
+    }
+    expect(h.state.pendingLoot["trade_room"]).toBeUndefined();
+  });
+
+  it("takeLoot refuses an item that exceeds carryCapacity", () => {
+    const h = harnessWithLoot("loot-2");
+    const anvil: ItemInstance = {
+      instanceId: "item_anvil",
+      templateId: "anvil",
+      name: "Stolen Anvil",
+      category: "material",
+      rarity: "common",
+      description: "Impossibly heavy.",
+      value: 50,
+      weight: 999,
+      stackable: false,
+      quantity: 1,
+      tags: [],
+      affixes: [],
+      states: []
+    };
+    h.state = {
+      ...h.state,
+      pendingLoot: {
+        ...h.state.pendingLoot,
+        trade_room: {
+          ...h.state.pendingLoot["trade_room"]!,
+          items: [...h.state.pendingLoot["trade_room"]!.items, anvil]
+        }
+      }
+    };
+    const result = act(h, { type: "takeLoot", itemInstanceId: "item_anvil" });
+    expect(narrativeText(result)).toContain("won't fit");
+    expect(h.state.pendingLoot["trade_room"]!.items.some(i => i.instanceId === "item_anvil")).toBe(true);
+  });
+
+  it("leaveLoot abandons the room's pool", () => {
+    const h = harnessWithLoot("loot-3");
+    act(h, { type: "leaveLoot" });
+    expect(h.state.pendingLoot["trade_room"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listen, lamp, map
+// ---------------------------------------------------------------------------
+
+describe("listen", () => {
+  it("hears hunters up to three rooms away, costs 1 oil, emits no noise", () => {
+    const h = makeHarness("listen-1");
+    // Candle Row is 3 rooms from the gullet (antechamber, tallow gallery, candle row).
+    h.state = {
+      ...h.state,
+      hunters: [{ id: "h1", enemyId: "goblin_snare", roomId: "candle_row", state: "dormant" }]
+    };
+    const before = h.state;
+    const result = act(h, { type: "listen" });
+    expect(h.state.lamp.oil).toBe(before.lamp.oil - 1);
+    expect(h.state.alertness).toBe(before.alertness); // listening is silent
+    expect(h.state.waterClock).toBe(before.waterClock - 1); // but time passes
+    expect(narrativeText(result)).toContain("3 rooms off");
+  });
+
+  it("reports silence when nothing is within reach", () => {
+    const h = makeHarness("listen-2");
+    h.state = { ...h.state, hunters: [] };
+    const result = act(h, { type: "listen" });
+    expect(narrativeText(result)).toContain("Nothing but your own blood");
+  });
+});
+
+describe("refillLamp", () => {
+  it("consumes a packed flask, fills to capacity, no tick", () => {
+    const h = makeHarness("lamp-1");
+    h.state = { ...h.state, lamp: { ...h.state.lamp, oil: 3 } };
+    const before = h.state;
+    const result = act(h, { type: "refillLamp" });
+    expect(h.state.lamp).toEqual({ oil: 20, capacity: 20, flasksPacked: 0 });
+    expect(h.state.waterClock).toBe(before.waterClock);
+    expect(result.events.some(e => e.kind === "flaskConsumed")).toBe(true);
+
+    const refusal = act(h, { type: "refillLamp" });
+    expect(narrativeText(refusal)).toContain("No oil left");
+  });
+});
+
+describe("consultMap", () => {
+  it("requires the map item", () => {
+    const h = makeHarness("map-1", { hasMapItem: false });
+    const before = h.state.lamp.oil;
+    const result = act(h, { type: "consultMap" });
+    expect(narrativeText(result)).toContain("no map");
+    expect(h.state.lamp.oil).toBe(before);
+  });
+
+  it("costs 1 oil and returns a map narrative entry in the light", () => {
+    const h = makeHarness("map-2", { hasMapItem: true });
+    const before = h.state.lamp.oil;
+    const result = act(h, { type: "consultMap" });
+    expect(result.narrative.some(n => n.kind === "map")).toBe(true);
+    expect(h.state.lamp.oil).toBe(before - 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// darkness
+// ---------------------------------------------------------------------------
+
+describe("dark light state", () => {
+  function darkHarness(seed: string): Harness {
+    const h = makeHarness(seed, { hasMapItem: true });
+    h.state = { ...h.state, lamp: { ...h.state.lamp, oil: 0, flasksPacked: 0 } };
+    expect(getLightState(h.state.lamp)).toBe("dark");
+    return h;
+  }
+
+  it("blocks search with a diegetic refusal", () => {
+    const h = darkHarness("dark-1");
+    const before = h.state;
+    const result = act(h, { type: "search" });
+    expect(narrativeText(result)).toContain("dark gives nothing up");
+    expect(h.state.alertness).toBe(before.alertness);
+    expect(h.state.searchedRoomIds).toEqual([]);
+  });
+
+  it("blocks consultMap with a diegetic refusal", () => {
+    const h = darkHarness("dark-2");
+    const result = act(h, { type: "consultMap" });
+    expect(narrativeText(result)).toContain("no light to read by");
+    expect(result.narrative.every(n => n.kind !== "map")).toBe(true);
+  });
+
+  it("doubles move noise: alertness rises by 2 for an unburdened move", () => {
+    const h = darkHarness("dark-3");
+    h.state = { ...h.state, hunters: [] }; // isolate noise accounting from fight noise
+    const before = h.state.alertness;
+    act(h, { type: "move", direction: "south" });
+    expect(h.state.alertness).toBe(before + 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// encounters
+// ---------------------------------------------------------------------------
+
+describe("encounters", () => {
+  it("opens on contact when moving into a hunter's room", () => {
+    const h = makeHarness("enc-1");
+    h.state = {
+      ...h.state,
+      hunters: [{ id: "h1", enemyId: "goblin_snare", roomId: "antechamber", state: "dormant" }]
+    };
+    const result = act(h, { type: "move", direction: "south" });
+    expect(h.state.activeEncounter).toBeDefined();
+    expect(h.state.activeEncounter!.hunterId).toBe("h1");
+    expect(result.narrative.some(n => n.kind === "encounter")).toBe(true);
+  });
+
+  it("blocks other actions while an encounter is active", () => {
+    const h = makeHarness("enc-2");
+    h.state = {
+      ...h.state,
+      hunters: [{ id: "h1", enemyId: "goblin_candle", roomId: "antechamber", state: "dormant" }]
+    };
+    act(h, { type: "move", direction: "south" });
+    expect(h.state.activeEncounter).toBeDefined();
+    const before = h.state;
+    const refused = act(h, { type: "search" });
+    expect(narrativeText(refused)).toContain("Deal with it first");
+    expect(h.state.lamp.oil).toBe(before.lamp.oil);
+  });
+
+  it("fight beats spend oil, emit fight noise, and a win removes the hunter", () => {
+    // Seed chosen so the warrior wins this fight without dying.
+    const h = makeHarness("enc-3");
+    h.state = {
+      ...h.state,
+      hunters: [{ id: "h1", enemyId: "goblin_candle", roomId: "antechamber", state: "dormant" }]
+    };
+    act(h, { type: "move", direction: "south" });
+    const alertnessBefore = h.state.alertness;
+    fightItOut(h);
+    expect(h.state.status).toBe("active");
+    expect(h.state.activeEncounter).toBeUndefined();
+    expect(h.state.hunters.find(hh => hh.id === "h1")).toBeUndefined();
+    expect(h.events.some(e => e.kind === "enemyDefeated")).toBe(true);
+    expect(h.state.alertness).toBeGreaterThan(alertnessBefore); // fight beats are loud
+  });
+
+  it("fallBack on success moves the player back the way they came", () => {
+    // Alertness 0 keeps the follow chance at its 20% floor; hunt a seed where the goblin doesn't follow.
+    for (let i = 0; i < 20; i++) {
+      const h = makeHarness(`enc-fallback-${i}`);
+      h.state = {
+        ...h.state,
+        hunters: [{ id: "h1", enemyId: "goblin_snare", roomId: "antechamber", state: "dormant" }]
+      };
+      act(h, { type: "move", direction: "south" });
+      expect(h.state.activeEncounter).toBeDefined();
+      const result = act(h, { type: "encounterOption", kind: "fallBack" });
+      if (narrativeText(result).includes("doesn't follow")) {
+        expect(h.state.currentRoomId).toBe("gullet");
+        expect(h.state.activeEncounter).toBeUndefined();
+        return;
+      }
+    }
+    throw new Error("no seed produced a clean fall-back in 20 tries");
+  });
+
+  it("unavailable options are refused with their reason", () => {
+    const h = makeHarness("enc-4");
+    h.state = {
+      ...h.state,
+      hunters: [{ id: "h1", enemyId: "goblin_candle", roomId: "antechamber", state: "dormant" }]
+    };
+    act(h, { type: "move", direction: "south" });
+    // No rations carried -> throwRations unavailable.
+    const result = act(h, { type: "encounterOption", kind: "throwRations" });
+    expect(narrativeText(result)).toContain("No rations");
+    expect(h.state.activeEncounter).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// death path
+// ---------------------------------------------------------------------------
+
+describe("death", () => {
+  it("a dying delver produces a died event and a dead run refuses further actions", () => {
+    for (let i = 0; i < 15; i++) {
+      const h = makeHarness(`death-${i}`);
+      h.character = { ...h.character, hp: 1 };
+      h.state = {
+        ...h.state,
+        hunters: [{ id: "h1", enemyId: "goblin_warrens_brute", roomId: "antechamber", state: "dormant" }]
+      };
+      act(h, { type: "move", direction: "south" });
+      fightItOut(h);
+      if (h.state.status === "dead") {
+        expect(h.events.some(e => e.kind === "died")).toBe(true);
+        const refused = act(h, { type: "move", direction: "north" });
+        expect(narrativeText(refused)).toContain("The run is over");
+        expect(h.state.currentRoomId).toBe("antechamber");
+        return;
+      }
+    }
+    throw new Error("no seed killed a 1-hp delver in 15 tries");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extracts
+// ---------------------------------------------------------------------------
+
+describe("extracts", () => {
+  it("the way you came: open below Hunting alertness, barred at or above it", () => {
+    const h = makeHarness("ext-1");
+    // Below the threshold: extraction succeeds from the gullet.
+    const open = act(h, { type: "extract", extractId: "f1_barred_door" });
+    expect(h.state.status).toBe("extracted");
+    expect(open.events).toContainEqual({ kind: "extracted", extractId: "f1_barred_door" });
+
+    // At Hunting alertness the same door is barred.
+    const h2 = makeHarness("ext-1b");
+    h2.state = { ...h2.state, alertness: HUNTING_POINTS };
+    expect(getThreatLevelFromPoints(h2.state.alertness)).toBe(3);
+    const barred = act(h2, { type: "extract", extractId: "f1_barred_door" });
+    expect(h2.state.status).toBe("active");
+    expect(barred.events).toEqual([]);
+    expect(narrativeText(barred)).toContain("barred from the other side");
+  });
+
+  it("driving alertness up through play bars the door", () => {
+    const h = makeHarness("ext-loud");
+    h.state = { ...h.state, hunters: [], alertness: HUNTING_POINTS - 2 };
+    act(h, { type: "move", direction: "south" }); // +1
+    act(h, { type: "move", direction: "north" }); // +1 -> crosses Hunting
+    expect(getThreatLevelFromPoints(h.state.alertness)).toBeGreaterThanOrEqual(3);
+    expect(h.events.some(e => e.kind === "alertnessLevel" && e.level === 3)).toBe(true);
+    expect(h.events.some(e => e.kind === "reinforcement")).toBe(true);
+    // The reinforcement guards the entrance; deal with it before trying the door.
+    fightItOut(h);
+    expect(h.state.status).toBe("active");
+    const result = act(h, { type: "extract", extractId: "f1_barred_door" });
+    expect(narrativeText(result)).toContain("barred from the other side");
+    expect(h.state.status).toBe("active");
+  });
+
+  it("the flooded stair: open while the water clock holds, closed at zero", () => {
+    const h = makeHarness("ext-2");
+    h.state = { ...h.state, currentRoomId: "flooded_stair", hunters: [] };
+    expect(h.state.waterClock).toBeGreaterThan(0);
+    act(h, { type: "extract", extractId: "f1_flooded_stair" });
+    expect(h.state.status).toBe("extracted");
+
+    const h2 = makeHarness("ext-2b");
+    h2.state = { ...h2.state, currentRoomId: "flooded_stair", hunters: [], waterClock: 0 };
+    const closed = act(h2, { type: "extract", extractId: "f1_flooded_stair" });
+    expect(h2.state.status).toBe("active");
+    expect(narrativeText(closed)).toContain("water has taken the stair");
+  });
+
+  it("draining the water clock through play closes the stair", () => {
+    const h = makeHarness("ext-drain", { waterClock: 2 });
+    h.state = { ...h.state, currentRoomId: "flooded_stair", hunters: [] };
+    act(h, { type: "listen" }); // waterClock 1
+    act(h, { type: "listen" }); // waterClock 0
+    expect(h.state.waterClock).toBe(0);
+    const closed = act(h, { type: "extract", extractId: "f1_flooded_stair" });
+    expect(h.state.status).toBe("active");
+    expect(narrativeText(closed)).toContain("water has taken the stair");
+  });
+
+  it("the rope winch: three loud cranks, then it carries you out", () => {
+    const h = makeHarness("ext-3");
+    h.state = { ...h.state, currentRoomId: "rope_winch", hunters: [] };
+
+    const early = act(h, { type: "extract", extractId: "f1_rope_winch" });
+    expect(narrativeText(early)).toContain("wants more cranking");
+
+    const alertnessBefore = h.state.alertness;
+    const oilBefore = h.state.lamp.oil;
+    act(h, { type: "crank", extractId: "f1_rope_winch" });
+    act(h, { type: "crank", extractId: "f1_rope_winch" });
+    act(h, { type: "crank", extractId: "f1_rope_winch" });
+    expect(h.state.cranksDone["f1_rope_winch"]).toBe(3);
+    expect(h.state.alertness).toBe(alertnessBefore + 12); // 3 cranks x loudness 4
+    expect(h.state.lamp.oil).toBe(oilBefore - 3);
+
+    act(h, { type: "extract", extractId: "f1_rope_winch" });
+    expect(h.state.status).toBe("extracted");
+    expect(h.events).toContainEqual({ kind: "extracted", extractId: "f1_rope_winch" });
+  });
+
+  it("refuses extraction from the wrong room", () => {
+    const h = makeHarness("ext-4");
+    h.state = { ...h.state, currentRoomId: "antechamber" };
+    const result = act(h, { type: "extract", extractId: "f1_barred_door" });
+    expect(narrativeText(result)).toContain("not in this room");
+    expect(h.state.status).toBe("active");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// descend
+// ---------------------------------------------------------------------------
+
+describe("descend", () => {
+  it("moves to floor 2, halves-down alertness by the carryover ratio, respawns hunters", () => {
+    const h = makeHarness("desc-1");
+    h.state = { ...h.state, currentRoomId: "deep_gallery", alertness: 50 };
+    const huntersBefore = h.state.hunters.map(hh => hh.id);
+
+    const result = act(h, { type: "descend", stairRoomId: "deep_gallery" });
+    expect(h.state.floor).toBe(2);
+    expect(h.state.currentRoomId).toBe("bonefire_hall");
+    expect(h.state.alertness).toBe(Math.floor(50 * 0.25)); // DEPTH_RULES.floorThreatCarryoverRatio
+    expect(result.events).toContainEqual({ kind: "descended", floor: 2 });
+
+    const floor2 = getPlace(PLACE_ID).floors[1]!;
+    const floor2SpawnRooms = new Set(floor2.rooms.filter(r => r.hunterSpawn).map(r => r.id));
+    expect(h.state.hunters.length).toBeGreaterThanOrEqual(floor2.hunterBudget.min);
+    for (const hunter of h.state.hunters) {
+      expect(floor2SpawnRooms.has(hunter.roomId)).toBe(true);
+      expect(huntersBefore).not.toContain(hunter.id);
+    }
+
+    // Floor 2 is playable: the always-open flue extract works.
+    h.state = { ...h.state, hunters: [] };
+    walkTo(h, "old_flue");
+    act(h, { type: "extract", extractId: "f2_old_flue" });
+    expect(h.state.status).toBe("extracted");
+  });
+
+  it("refuses to descend from a room the player is not in", () => {
+    const h = makeHarness("desc-2");
+    const result = act(h, { type: "descend", stairRoomId: "deep_gallery" });
+    expect(narrativeText(result)).toContain("not in this room");
+    expect(h.state.floor).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// determinism
+// ---------------------------------------------------------------------------
+
+describe("determinism", () => {
+  it("the same seed and action script produce identical states and narrative", () => {
+    const script: DelveAction[] = [
+      { type: "move", direction: "south" },
+      { type: "listen" },
+      { type: "move", direction: "south" },
+      { type: "search" },
+      { type: "takeAllLoot" },
+      { type: "move", direction: "east" },
+      { type: "move", direction: "north" },
+      { type: "search" },
+      { type: "takeAllLoot" }
+    ];
+    const run = () => {
+      const h = makeHarness("det-1");
+      for (const action of script) {
+        if (h.state.status !== "active") break;
+        if (h.state.activeEncounter) fightItOut(h);
+        if (h.state.status !== "active") break;
+        act(h, action);
+      }
+      if (h.state.activeEncounter) fightItOut(h);
+      return h;
+    };
+    const a = run();
+    const b = run();
+    expect(a.state).toEqual(b.state);
+    expect(a.events).toEqual(b.events);
+    expect(a.state.narrative.map(n => n.text)).toEqual(b.state.narrative.map(n => n.text));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// full-run integration
+// ---------------------------------------------------------------------------
+
+describe("full-run integration", () => {
+  it("enter, delve to the trade room, search, loot, and walk out the way you came", () => {
+    const h = makeHarness("full-1");
+    walkTo(h, "trade_room");
+    if (h.state.status !== "active") throw new Error("delver died on the approach; pick a new seed");
+    act(h, { type: "search" });
+    if (h.state.activeEncounter) fightItOut(h);
+    if (h.state.pendingLoot["trade_room"]) {
+      act(h, { type: "takeAllLoot" });
+      expect(h.carried.length + h.events.filter(e => e.kind === "itemsTaken").length).toBeGreaterThan(0);
+    }
+    walkTo(h, "gullet");
+    expect(h.state.status).toBe("active");
+    expect(getThreatLevelFromPoints(h.state.alertness)).toBeLessThan(3);
+    act(h, { type: "extract", extractId: "f1_barred_door" });
+    expect(h.state.status).toBe("extracted");
+    expect(h.events.some(e => e.kind === "extracted")).toBe(true);
+    // The lamp did real work along the way.
+    expect(h.state.lamp.oil).toBeLessThan(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Risk/reward simulation (in the style of riskRewardSimulation.test.ts):
+// a cautious bot banks a small pack and leaves; a greedy bot searches
+// everything and pays for it.
+// ---------------------------------------------------------------------------
+
+interface DelveSimResult {
+  seed: string;
+  outcome: "extracted" | "dead" | "trapped";
+  steps: number;
+  roomsSearched: number;
+  packValue: number;
+  alertnessAtEnd: number;
+  extractUsed?: string;
+}
+
+type BotPolicy = "cautious" | "greedy";
+
+function runDelveBot(seed: string, policy: BotPolicy): DelveSimResult {
+  const h = makeHarness(seed, { flasksPacked: 1 });
+  const floor = floor1();
+  const adjacency = buildAdjacency(floor);
+  const entranceDistances = bfsDistances(adjacency, floor.entranceRoomId);
+
+  // Search targets. The cautious bot plays like someone who has learned the
+  // place: two marked rooms near the entrance, in and out. The greedy bot
+  // doesn't know what's marked — it turns over every room on the floor.
+  const supplyRooms = h.state.supplyCaches.map(c => c.roomId);
+  const markedTargets = [...new Set([...h.state.lootRoomIds, ...supplyRooms])];
+  const targets = policy === "greedy"
+    ? floor.rooms.map(r => r.id)
+    : markedTargets.filter(id => (entranceDistances[id] ?? 99) <= 4).slice(0, 2);
+
+  let failedBarredDoor = false;
+  let failedStair = false;
+  let extractUsed: string | undefined;
+
+  const finishSim = (outcome: DelveSimResult["outcome"], steps: number): DelveSimResult => ({
+    seed,
+    outcome,
+    steps,
+    roomsSearched: h.state.searchedRoomIds.length,
+    packValue: h.carried.reduce((sum, i) => sum + i.value * i.quantity, 0),
+    alertnessAtEnd: h.state.alertness,
+    extractUsed
+  });
+
+  for (let step = 0; step < 250; step++) {
+    if (h.state.status === "extracted") return finishSim("extracted", step);
+    if (h.state.status === "dead") return finishSim("dead", step);
+
+    // Encounters first.
+    if (h.state.activeEncounter) {
+      const enc = h.state.activeEncounter;
+      const slip = enc.options.find(o => o.kind === "slipPast");
+      if (policy === "cautious" && enc.beat === 1 && slip?.available) {
+        act(h, { type: "encounterOption", kind: "slipPast" });
+      } else {
+        act(h, { type: "fightBeat", stance: "press" });
+      }
+      continue;
+    }
+
+    // Lamp upkeep.
+    if (h.state.lamp.oil <= 2 && h.state.lamp.flasksPacked > 0) {
+      act(h, { type: "refillLamp" });
+      continue;
+    }
+
+    // Bag anything at our feet.
+    const pool = h.state.pendingLoot[h.state.currentRoomId];
+    if (pool && (pool.items.length > 0 || pool.gold > 0)) {
+      act(h, { type: "takeAllLoot" });
+      continue;
+    }
+
+    const light = getLightState(h.state.lamp);
+    const unsearched = targets.filter(id => !h.state.searchedRoomIds.includes(id));
+
+    // Cautious bots know when to stop; greedy bots stop only when done or blind.
+    const level = getThreatLevelFromPoints(h.state.alertness);
+    const shouldExtract = policy === "cautious"
+      ? unsearched.length === 0 ||
+        level >= 2 ||
+        h.state.lamp.oil + h.state.lamp.flasksPacked * h.state.lamp.capacity < 10 ||
+        h.character.hp < h.character.maxHp * 0.5
+      : unsearched.length === 0 || (light === "dark" && h.state.lamp.flasksPacked === 0);
+
+    if (!shouldExtract) {
+      if (unsearched.includes(h.state.currentRoomId) && light !== "dark") {
+        act(h, { type: "search" });
+        continue;
+      }
+      // Head for the nearest unsearched target.
+      const distances = bfsDistances(adjacency, h.state.currentRoomId);
+      const reachable = unsearched.filter(id => distances[id] !== undefined);
+      if (reachable.length === 0) {
+        // One-way drops can strand targets behind us; give up and leave.
+        failedBarredDoor = failedBarredDoor || false;
+      } else {
+        const nearest = reachable.sort((a, b) => distances[a]! - distances[b]!)[0]!;
+        const path = bfsPath(adjacency, h.state.currentRoomId, nearest)!;
+        act(h, { type: "move", direction: directionBetween(floor, h.state.currentRoomId, path[1]!) });
+        continue;
+      }
+    }
+
+    // Extraction phase: the way you came, then the stair, then the winch.
+    let goal: string;
+    if (!failedBarredDoor && level < 3) {
+      goal = "gullet";
+      if (h.state.currentRoomId === goal) {
+        extractUsed = "f1_barred_door";
+        act(h, { type: "extract", extractId: "f1_barred_door" });
+        if (h.state.status === "active") failedBarredDoor = true;
+        continue;
+      }
+    } else if (!failedStair && h.state.waterClock > 0) {
+      goal = "flooded_stair";
+      if (h.state.currentRoomId === goal) {
+        extractUsed = "f1_flooded_stair";
+        act(h, { type: "extract", extractId: "f1_flooded_stair" });
+        if (h.state.status === "active") failedStair = true;
+        continue;
+      }
+    } else {
+      goal = "rope_winch";
+      if (h.state.currentRoomId === goal) {
+        if ((h.state.cranksDone["f1_rope_winch"] ?? 0) < 3) {
+          act(h, { type: "crank", extractId: "f1_rope_winch" });
+        } else {
+          extractUsed = "f1_rope_winch";
+          act(h, { type: "extract", extractId: "f1_rope_winch" });
+        }
+        continue;
+      }
+    }
+    if (level >= 3) failedBarredDoor = true;
+
+    const path = bfsPath(adjacency, h.state.currentRoomId, goal);
+    if (!path || path.length < 2) return finishSim("trapped", step);
+    act(h, { type: "move", direction: directionBetween(floor, h.state.currentRoomId, path[1]!) });
+  }
+  return finishSim("trapped", 250);
+}
+
+describe("delve risk/reward simulation", () => {
+  it("a cautious delver extracts most runs; greed makes the floor tilt", () => {
+    const RUNS = 40;
+    const cautious = Array.from({ length: RUNS }, (_, i) => runDelveBot(`delve-sim-c-${i + 1}`, "cautious"));
+    const greedy = Array.from({ length: RUNS }, (_, i) => runDelveBot(`delve-sim-g-${i + 1}`, "greedy"));
+
+    const summarize = (label: string, results: DelveSimResult[]) => {
+      const extracted = results.filter(r => r.outcome === "extracted");
+      const dead = results.filter(r => r.outcome === "dead");
+      const trapped = results.filter(r => r.outcome === "trapped");
+      const avg = (xs: number[]) => (xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length);
+      console.info("delve simulation", {
+        label,
+        runs: results.length,
+        extracted: extracted.length,
+        dead: dead.length,
+        trapped: trapped.length,
+        avgSearched: Number(avg(results.map(r => r.roomsSearched)).toFixed(1)),
+        avgPackValue: Number(avg(extracted.map(r => r.packValue)).toFixed(1)),
+        avgAlertness: Number(avg(results.map(r => r.alertnessAtEnd)).toFixed(1))
+      });
+      return { extracted, dead, trapped };
+    };
+
+    const c = summarize("cautious", cautious);
+    const g = summarize("greedy", greedy);
+
+    const cautiousExtractRate = c.extracted.length / RUNS;
+    const cautiousBadRate = (c.dead.length + c.trapped.length) / RUNS;
+    const greedyBadRate = (g.dead.length + g.trapped.length) / RUNS;
+
+    // The design doc's balance target: a competent, cautious run gets out.
+    expect(cautiousExtractRate).toBeGreaterThan(0.7);
+    // Greed pays: substantially more deaths/trappings than playing it safe.
+    // (Observed: cautious 0/40 bad outcomes, greedy 7/40 — the tilt is real,
+    // though most of it is death-by-goblin; the barred door rarely springs
+    // because the oil budget ends greedy runs before alertness reaches
+    // Hunting. See the run-layer report for the retuning argument.)
+    expect(greedyBadRate).toBeGreaterThanOrEqual(cautiousBadRate + 0.1);
+    expect(greedyBadRate).toBeGreaterThanOrEqual(0.15);
+    // Greed also has to be worth attempting: greedy extractions carry more value.
+    const avgValue = (rs: DelveSimResult[]) =>
+      rs.length === 0 ? 0 : rs.reduce((sum, r) => sum + r.packValue, 0) / rs.length;
+    if (g.extracted.length > 0 && c.extracted.length > 0) {
+      expect(avgValue(g.extracted)).toBeGreaterThan(avgValue(c.extracted));
+    }
+  });
+});

--- a/src/tests/delveScreenChoices.test.ts
+++ b/src/tests/delveScreenChoices.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { createDelveRun } from "../game/delve/delveRun";
+import type { ActiveEncounter, DelveRunState } from "../game/delve/types";
+import { buildChoiceList } from "../screens/delveChoices";
+
+const PLACE_ID = "goblinWarrens";
+
+function freshRun(overrides: Partial<DelveRunState> = {}): DelveRunState {
+  const state = createDelveRun({ placeId: PLACE_ID, seed: "choices-1", flasksPacked: 1 });
+  return { ...state, ...overrides };
+}
+
+describe("buildChoiceList", () => {
+  it("at the entrance, offers the single move exit, search, listen, refill lamp, extract, and descend", () => {
+    const state = freshRun(); // starts at "gullet": one exit south, and the "way you came" extract
+    const choices = buildChoiceList(state);
+
+    expect(choices).toContainEqual(expect.objectContaining({ kind: "move", direction: "south" }));
+    expect(choices).toContainEqual(expect.objectContaining({ kind: "search" }));
+    expect(choices).toContainEqual(expect.objectContaining({ kind: "listen" }));
+    expect(choices).toContainEqual(expect.objectContaining({ kind: "refillLamp" }));
+    expect(choices).toContainEqual(expect.objectContaining({ kind: "extract", extractId: "f1_barred_door" }));
+    expect(choices).toContainEqual(expect.objectContaining({ kind: "descend" }));
+    expect(choices.some(c => c.kind === "consultMap")).toBe(false);
+    expect(choices.some(c => c.kind === "crank")).toBe(false);
+  });
+
+  it("drops the search choice once the current room has been searched", () => {
+    const state = freshRun({ searchedRoomIds: ["gullet"] });
+    const choices = buildChoiceList(state);
+    expect(choices.some(c => c.kind === "search")).toBe(false);
+  });
+
+  it("hides refill lamp when no flasks are packed", () => {
+    const state = freshRun({ lamp: { oil: 20, capacity: 20, flasksPacked: 0 } });
+    const choices = buildChoiceList(state);
+    expect(choices.some(c => c.kind === "refillLamp")).toBe(false);
+  });
+
+  it("offers consult the map only with the map item and some oil left", () => {
+    const withMap = freshRun({ hasMapItem: true });
+    expect(buildChoiceList(withMap).some(c => c.kind === "consultMap")).toBe(true);
+
+    const darkWithMap = freshRun({ hasMapItem: true, lamp: { oil: 0, capacity: 20, flasksPacked: 1 } });
+    expect(buildChoiceList(darkWithMap).some(c => c.kind === "consultMap")).toBe(false);
+
+    const noMap = freshRun({ hasMapItem: false });
+    expect(buildChoiceList(noMap).some(c => c.kind === "consultMap")).toBe(false);
+  });
+
+  it("pending loot in the current room replaces exits/contextual choices with take-all/leave", () => {
+    const state = freshRun({
+      pendingLoot: {
+        gullet: { items: [], gold: 5, materials: {} }
+      }
+    });
+    const choices = buildChoiceList(state);
+    expect(choices).toEqual([
+      { kind: "takeAllLoot", label: "Take All" },
+      { kind: "leaveLoot", label: "Leave the Rest" }
+    ]);
+  });
+
+  it("an active encounter surfaces its non-fight options plus all three stance buttons, in that priority", () => {
+    const encounter: ActiveEncounter = {
+      hunterId: "h1",
+      enemyId: "goblin_skulker",
+      enemyHp: 10,
+      enemyMaxHp: 10,
+      beat: 1,
+      options: [
+        { kind: "fight", label: "Meet it head-on", available: true },
+        { kind: "slipPast", label: "Slip along the far wall", available: true },
+        { kind: "fallBack", label: "Fall back the way you came", available: false, unavailableReason: "No way back" }
+      ],
+      log: []
+    };
+    const state = freshRun({ activeEncounter: encounter });
+    const choices = buildChoiceList(state);
+
+    // "fight" is realized via stance buttons, not surfaced as its own option.
+    expect(choices.some(c => c.kind === "encounterOption" && c.optionKind === "fight")).toBe(false);
+    expect(choices).toContainEqual(
+      expect.objectContaining({ kind: "encounterOption", optionKind: "slipPast", available: true })
+    );
+    expect(choices).toContainEqual(
+      expect.objectContaining({ kind: "encounterOption", optionKind: "fallBack", available: false, unavailableReason: "No way back" })
+    );
+    const stances = choices.filter(c => c.kind === "fightStance").map(c => (c as { stance: string }).stance);
+    expect(stances).toEqual(["press", "guard", "breakAway"]);
+
+    // Encounter takes priority even if there also happens to be pending loot in the room.
+    const stateWithLootToo: DelveRunState = {
+      ...state,
+      pendingLoot: { gullet: { items: [], gold: 3, materials: {} } }
+    };
+    expect(buildChoiceList(stateWithLootToo).some(c => c.kind === "takeAllLoot")).toBe(false);
+  });
+
+  it("offers crank while cranks remain, then switches to extract once the winch is done", () => {
+    const partiallyCranked = freshRun({ currentRoomId: "rope_winch", cranksDone: { f1_rope_winch: 1 } });
+    const cranked = buildChoiceList(partiallyCranked);
+    expect(cranked).toContainEqual({ kind: "crank", extractId: "f1_rope_winch", label: "Crank the winch (1/3)" });
+    expect(cranked.some(c => c.kind === "extract")).toBe(false);
+
+    const fullyCranked = freshRun({ currentRoomId: "rope_winch", cranksDone: { f1_rope_winch: 3 } });
+    const doneChoices = buildChoiceList(fullyCranked);
+    expect(doneChoices.some(c => c.kind === "crank")).toBe(false);
+    expect(doneChoices).toContainEqual(expect.objectContaining({ kind: "extract", extractId: "f1_rope_winch" }));
+  });
+
+  it("returns no choices once the run is no longer active", () => {
+    const extracted = freshRun({ status: "extracted" });
+    expect(buildChoiceList(extracted)).toEqual([]);
+    const dead = freshRun({ status: "dead" });
+    expect(buildChoiceList(dead)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Structural rebuild of the run layer per docs/design/the-delve.md. Closes #33, #34, #35, #36, #37.

## What changed
- **Engine core** — `src/game/delve/`: oil-lamp clock with light states (`lamp.ts`), noise propagation over the room graph (`noise.ts`), positional hunter simulation with dormant/roaming/drawn/hunting states (`hunters.ts`).
- **Authored place** — the Goblin Warrens: two fixed 27-room floors, 14 landmarks, one-way shortcuts, sensory-tagged exits, three conditioned extracts (barred door / flooded stair / rope winch), full authoring validator (`place.ts`, `places/goblinWarrens.ts`).
- **Inline encounters** — 1–3-beat fights with stance choices (press/guard/break away) aggregating the existing combat math; slip/fall-back/parley/rations/lure options gated by light, pack weight, and enemy intelligence (`encounters.ts`).
- **Run state machine** — pure reducer (`delveRun.ts`) composing all of it: 13 actions, water clock, alertness escalation with reinforcements, dark-lamp restrictions, extract validation.
- **DelveScreen** — single narrative column replacing dungeon+combat screens for delve runs; prose exits, quiet status strip (HP / lamp / pack / alertness), inline choices; store slice bridges extraction/death into the existing v0.4 reward/death-cost/summary flows.

## Verification
- 363/363 tests, including bot-simulation assertions: cautious play extracts >70% (measured 100%), greedy play takes ≥15% bad outcomes (measured 17.5%).
- Manual browser playthrough of the full arc: enter → fight (2/36 HP survival) → chain contact from fight noise → slip past → loot → navigate home from memory → extract → run summary.

## Known follow-ups (tracked on #38)
Descend stair authoring, encounter depth scaling on floor 2, ration tag, map-sketch rendering, barred-door balance, quest/prep integration, dev-panel overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)